### PR TITLE
GD-86: Fixes space in folder name prevents tests from running

### DIFF
--- a/PackageVersions.props
+++ b/PackageVersions.props
@@ -5,5 +5,7 @@
     <MicrosoftSdkVersion>17.9.0</MicrosoftSdkVersion>
     <MicrosoftCodeAnalysisCSharpVersion>4.9.2</MicrosoftCodeAnalysisCSharpVersion>
     <MoqVersion>4.18.4</MoqVersion>
+    <GdUnitAPIVersion>4.2.3</GdUnitAPIVersion>
+    <GdUnitTestAdapterVersion>1.1.1</GdUnitTestAdapterVersion>
   </PropertyGroup>
 </Project>

--- a/api/gdUnit4Api.csproj
+++ b/api/gdUnit4Api.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Title>gdUnit4Api</Title>
-    <Version>4.2.3</Version>
+    <Version>$(GdUnitAPIVersion)</Version>
     <Description>
       GdUnit4 API is the C# extention to enable GdUnit4 to run/write unit tests in C#.
     </Description>
@@ -34,7 +34,7 @@
     <IsPackable>true</IsPackable>
     <PackageProjectUrl>https://github.com/MikeSchulze/gdUnit4Net</PackageProjectUrl>
     <PackageId>gdUnit4.api</PackageId>
-    <PackageVersion>4.2.3</PackageVersion>
+    <PackageVersion>$(GdUnitAPIVersion)</PackageVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>GdUnit4 API release candidate.</PackageReleaseNotes>

--- a/example/exampleProject.csproj
+++ b/example/exampleProject.csproj
@@ -18,6 +18,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftSdkVersion)" />
     <PackageReference Include="gdUnit4.api" Version="4.2.*" />
-    <PackageReference Include="gdUnit4.test.adapter" Version="1.*-*" />
+    <PackageReference Include="gdUnit4.test.adapter" Version="1.*" />
   </ItemGroup>
 </Project>

--- a/testadapter/gdUnit4TestAdapter.csproj
+++ b/testadapter/gdUnit4TestAdapter.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Title>gdUnit4TestAdapter</Title>
-    <Version>1.1.0</Version>
+    <Version>$(GdUnitTestAdapterVersion)</Version>
     <Description>
       GdUnit4 Test Adapter is the test adapter to run GdUnit4 tests in C#.
     </Description>
@@ -33,7 +33,7 @@
     <IsPackable>true</IsPackable>
     <PackageProjectUrl>https://github.com/MikeSchulze/gdUnit4Net</PackageProjectUrl>
     <PackageId>gdUnit4.test.adapter</PackageId>
-    <PackageVersion>1.1.0</PackageVersion>
+    <PackageVersion>$(GdUnitTestAdapterVersion)</PackageVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>GdUnit4 Test Adapter beta.</PackageReleaseNotes>


### PR DESCRIPTION
# Why
https://github.com/MikeSchulze/gdUnit4Net/issues/86

# What
* fixed the arguments that include paths by surrounding by quotes.
* set working directory to project path
* use current working directory to set the `--path .` argument
* introduce package version properties to centralize the API versions
* bump adapter version to v1.1.1