### PR TITLE
GD-89: Add input action support to the `SceneRunner`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_gdunit4_api.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_gdunit4_api.yaml
@@ -1,8 +1,7 @@
 name: GdUnit4.API Bug Report
 description: Report a GdUnit4 bug related to the API
-title: "GD-XXX: Describe the issue briefly"
-labels: ["bug", "gdunit4.api"]
-projects: ["projects/6"]
+title: 'GD-XXX: Describe the issue briefly'
+labels: ['bug', 'gdunit4.api']
 assignees:
   - MikeSchulze
 
@@ -14,15 +13,15 @@ body:
         - Please search [open](https://github.com/MikeSchulze/gdUnit4Net/issues?q=is%3Aissue) for existing issues for potential duplicates before submit yours.
         - Verify that you are using a [supported Godot version](https://docs.godotengine.org/en/stable/about/release_policy.html). Please always check if your issue is reproducible in the latest version – it may already have been fixed!
 
-
   - type: dropdown
     id: gdunit4-api-version
     attributes:
       label: The used API version
       description: Which **gdunit4.api** version are you using?
       options:
-        - 4.2.3-rc1 (Pre Release/Master branch)
-        - 4.2.2 (Latest Release)
+        - 4.2.4-rc1 (Pre Release/Master branch)
+        - 4.2.3 (Latest Release)
+        - 4.2.2
         - 4.2.1.1
         - 4.2.1
         - 4.2.0
@@ -46,7 +45,7 @@ body:
       description: |
         What operating system are you using?
         - Specify the OS version, and when relevant hardware information.
-      placeholder: "Example: macOS Big Sur"
+      placeholder: 'Example: macOS Big Sur'
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_gdunit4_test_adapter.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_gdunit4_test_adapter.yaml
@@ -1,8 +1,7 @@
 name: GdUnit4 Test Adapter Bug Report
 description: Report a GdUnit4 bug related to the Test Adapter
-title: "GD-XXX: Describe the issue briefly"
-labels: ["bug", "gdunit4.test.adapter"]
-projects: ["projects/6"]
+title: 'GD-XXX: Describe the issue briefly'
+labels: ['bug', 'gdunit4.test.adapter']
 assignees:
   - MikeSchulze
 
@@ -14,7 +13,6 @@ body:
         - Please search [open](https://github.com/MikeSchulze/gdUnit4Net/issues?q=is%3Aissue) for existing issues for potential duplicates before submit yours.
         - Verify that you are using a [supported Godot version](https://docs.godotengine.org/en/stable/about/release_policy.html). Please always check if your issue is reproducible in the latest version – it may already have been fixed!
 
-
   - type: dropdown
     id: gdunit4-api-version
     attributes:
@@ -22,6 +20,7 @@ body:
       description: Which **gdunit4.test.adapter** version are you using?
       options:
         - 1.2.0 (Pre Release/Master branch)
+        - 1.1.1
         - 1.1.0
         - 1.0.0
       default: 0
@@ -44,7 +43,7 @@ body:
       description: |
         What operating system are you using?
         - Specify the OS version, and when relevant hardware information.
-      placeholder: "Example: macOS Big Sur"
+      placeholder: 'Example: macOS Big Sur'
     validations:
       required: true
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -22,11 +22,9 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.2', '4.2.1']
+        godot-version: ['4.2', '4.2.1', '4.2.2']
         godot-status: ['stable']
         include:
-          - godot-version: '4.2.2'
-            godot-status: 'rc2'
           - godot-version: '4.3'
             godot-status: 'dev5'
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,6 +26,7 @@
     "Clazz",
     "Cmdline",
     "configfile",
+    "Deadzone",
     "dorny",
     "Extr",
     "Fullqualified",

--- a/PackageVersions.props
+++ b/PackageVersions.props
@@ -5,7 +5,7 @@
     <MicrosoftSdkVersion>17.9.0</MicrosoftSdkVersion>
     <MicrosoftCodeAnalysisCSharpVersion>4.9.2</MicrosoftCodeAnalysisCSharpVersion>
     <MoqVersion>4.18.4</MoqVersion>
-    <GdUnitAPIVersion>4.2.3</GdUnitAPIVersion>
+    <GdUnitAPIVersion>4.2.4</GdUnitAPIVersion>
     <GdUnitTestAdapterVersion>1.1.1</GdUnitTestAdapterVersion>
   </PropertyGroup>
 </Project>

--- a/api/ReleaseNotes.txt
+++ b/api/ReleaseNotes.txt
@@ -1,4 +1,14 @@
 
+V4.2.4
+
+Improvements:
+- Added input action handling to the SceneRunner
+  - `SimulateActionPressed(string action)`
+  - `SimulateActionPress(string action)`
+  - `SimulateActionRelease(string action)`
+
+-------------------------------------------------------------------------------------------------------
+
 v4.2.3
 
 Bug Fixes:

--- a/api/src/ISceneRunner.cs
+++ b/api/src/ISceneRunner.cs
@@ -35,6 +35,28 @@ public interface ISceneRunner : IDisposable
     /// <returns></returns>
     public static ISceneRunner Load(string resourcePath, bool autofree = false, bool verbose = false) => new Core.SceneRunner(resourcePath, autofree, verbose);
 
+
+    /// <summary>
+    /// Simulates that an action has been pressed.
+    /// </summary>
+    /// <param name="action">The name of the action, e.g., "ui_up".</param>
+    /// <returns>The SceneRunner instance.</returns>
+    ISceneRunner SimulateActionPressed(string action);
+
+    /// <summary>
+    /// Simulates that an action is press.
+    /// </summary>
+    /// <param name="action">The name of the action, e.g., "ui_up".</param>
+    /// <returns>The SceneRunner instance.</returns>
+    ISceneRunner SimulateActionPress(string action);
+
+    /// <summary>
+    /// Simulates that an action has been released.
+    /// </summary>
+    /// <param name="action">The name of the action, e.g., "ui_up".</param>
+    /// <returns>The SceneRunner instance.</returns>
+    ISceneRunner SimulateActionRelease(string action);
+
     /// <summary>
     /// Simulates that a key has been pressed.
     /// </summary>


### PR DESCRIPTION
# Why
We want to simulate input actions on a running scene.

# What
added new simulate methods to the SceneRunner
```cs
    /// <summary>
    /// Simulates that an action has been pressed.
    /// </summary>
    /// <param name="action">The name of the action, e.g., "ui_up".</param>
    /// <returns>The SceneRunner instance.</returns>
    ISceneRunner SimulateActionPressed(string action);

    /// <summary>
    /// Simulates that an action is press.
    /// </summary>
    /// <param name="action">The name of the action, e.g., "ui_up".</param>
    /// <returns>The SceneRunner instance.</returns>
    ISceneRunner SimulateActionPress(string action);

    /// <summary>
    /// Simulates that an action has been released.
    /// </summary>
    /// <param name="action">The name of the action, e.g., "ui_up".</param>
    /// <returns>The SceneRunner instance.</returns>
    ISceneRunner SimulateActionRelease(string action);
```