### PR TITLE
GD-90: Cleanup old runner configuration before run new tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ nupkg/*
 *.*.import
 TestResults/
 gdunit4_testadapter/
+**GdUnitRunner_*.cfg
 
 # Mono-specific ignores
 .mono/

--- a/testadapter/src/execution/BaseTestExecutor.cs
+++ b/testadapter/src/execution/BaseTestExecutor.cs
@@ -40,6 +40,10 @@ internal abstract class BaseTestExecutor
 
     protected static string WriteTestRunnerConfig(Dictionary<string, List<TestCase>> groupedTestSuites)
     {
+        try
+        { CleanupRunnerConfigurations(); }
+        catch (Exception) { }
+
         var fileName = $"GdUnitRunner_{Guid.NewGuid()}.cfg";
         var filePath = Path.Combine(Directory.GetCurrentDirectory(), fileName);
 
@@ -54,6 +58,11 @@ internal abstract class BaseTestExecutor
         File.WriteAllText(filePath, JsonConvert.SerializeObject(testConfig, Formatting.Indented));
         return filePath;
     }
+
+    private static void CleanupRunnerConfigurations()
+        => Directory.GetFiles(Directory.GetCurrentDirectory(), "GdUnitRunner_*.cfg")
+            .ToList()
+            .ForEach(File.Delete);
 
     protected static void AttachDebuggerIfNeed(IRunContext runContext, IFrameworkHandle frameworkHandle, Process process)
     {


### PR DESCRIPTION
# Why
On Visual Studio, there are leftovers when press stop debug on a test session. This results into a `The active test run was aborted. Reason: Test host process crashed` This crash can't be handled by the test executor because the process is lost.

# What
- added to `.gitignore` a rule do not push runner config files
- do delete now old runner config files if exist before write the new one. This is just a workaround to clean up the working directory

