### PR TITLE
GD-96: Fix methods with a single parameterized test case are not executed

### DIFF
--- a/PackageVersions.props
+++ b/PackageVersions.props
@@ -5,7 +5,7 @@
     <MicrosoftSdkVersion>17.9.0</MicrosoftSdkVersion>
     <MicrosoftCodeAnalysisCSharpVersion>4.9.2</MicrosoftCodeAnalysisCSharpVersion>
     <MoqVersion>4.18.4</MoqVersion>
-    <GdUnitAPIVersion>4.2.4-rc1</GdUnitAPIVersion>
+    <GdUnitAPIVersion>4.2.4-rc2</GdUnitAPIVersion>
     <GdUnitTestAdapterVersion>1.1.1</GdUnitTestAdapterVersion>
   </PropertyGroup>
 </Project>

--- a/api/src/core/execution/TestCase.cs
+++ b/api/src/core/execution/TestCase.cs
@@ -26,6 +26,8 @@ internal sealed class TestCase
 
     public TestCaseAttribute TestCaseAttribute => MethodInfo.GetCustomAttribute<TestCaseAttribute>()!;
 
+    internal bool IsParameterized => TestCaseAttributes.Any(p => p.Arguments.Length > 0);
+
     public bool IsSkipped => Attribute.IsDefined(MethodInfo, typeof(IgnoreUntilAttribute));
 
     private IEnumerable<object> Parameters

--- a/api/src/core/execution/TestSuiteExecutionStage.cs
+++ b/api/src/core/execution/TestSuiteExecutionStage.cs
@@ -31,7 +31,7 @@ internal sealed class TestSuiteExecutionStage : IExecutionStage
         foreach (var testCase in testSuiteContext.TestSuite.TestCases)
         {
             using var testCaseContext = new ExecutionContext(testSuiteContext, testCase);
-            if (testCase.TestCaseAttributes.Count() > 1)
+            if (testCase.IsParameterized)
                 await RunParameterizedTest(testCaseContext, testCase);
             else
                 await RunTestCase(testCaseContext, testCase, testCase.TestCaseAttribute, testCase.Arguments);

--- a/test/src/core/ExampleTestSuite.cs
+++ b/test/src/core/ExampleTestSuite.cs
@@ -67,4 +67,8 @@ public class ExampleTestSuite
         AssertThat(a + b + c).IsEqual(expect);
 #pragma warning restore IDE0022 // Use expression body for method
     }
+
+    [TestCase(true)]
+    public void ParameterizedSingleTest(bool value)
+        => AssertThat(value).IsTrue();
 }

--- a/test/src/core/ExecutorTest.cs
+++ b/test/src/core/ExecutorTest.cs
@@ -648,14 +648,15 @@ public class ExecutorTest : ITestEventListener
         AssertArray(testSuite.TestCases).Extract("Name").ContainsExactly(new string[] {
             "ParameterizedBoolValue",
             "ParameterizedIntValues",
-            "ParameterizedIntValuesFail" });
+            "ParameterizedIntValuesFail",
+            "ParameterizedSingleTest" });
 
         var events = await ExecuteTestSuite(testSuite);
 
         var suiteName = "TestSuiteParameterizedTests";
         var expectedEvents = new List<ITuple>
         {
-            Tuple(TESTSUITE_BEFORE, suiteName, "Before", 3)
+            Tuple(TESTSUITE_BEFORE, suiteName, "Before", 4)
         };
         expectedEvents.AddRange(ExpectedTestCase(suiteName, "ParameterizedBoolValue", new List<object[]> {
             new object[] { 0, false }, new object[] { 1, true } }));
@@ -663,6 +664,8 @@ public class ExecutorTest : ITestEventListener
             new object[] { 1, 2, 3, 6 }, new object[] { 3, 4, 5, 12 }, new object[] { 6, 7, 8, 21 } }));
         expectedEvents.AddRange(ExpectedTestCase(suiteName, "ParameterizedIntValuesFail", new List<object[]> {
             new object[] { 1, 2, 3, 6 }, new object[] { 3, 4, 5, 11 }, new object[] { 6, 7, 8, 22 } }));
+        expectedEvents.AddRange(ExpectedTestCase(suiteName, "ParameterizedSingleTest", new List<object[]> {
+            new object[] { true } }));
         expectedEvents.Add(Tuple(TESTSUITE_AFTER, suiteName, "After", 0));
         AssertTestCaseNames(events).ContainsExactly(expectedEvents);
 
@@ -683,6 +686,11 @@ public class ExecutorTest : ITestEventListener
             Tuple(TESTCASE_AFTER, TestCase.BuildDisplayName("ParameterizedIntValuesFail", new object[] { 3, 4, 5, 11 }), false, false, true, false),
             Tuple(TESTCASE_AFTER, TestCase.BuildDisplayName("ParameterizedIntValuesFail", new object[] { 6, 7, 8, 22 }), false, false, true, false),
             Tuple(TESTCASE_AFTER, TestCase.BuildDisplayName("ParameterizedIntValuesFail"), false, false, true, false),
+            // the single parameterized test
+            Tuple(TESTCASE_BEFORE, "ParameterizedSingleTest", true, false, false, false),
+            Tuple(TESTCASE_BEFORE, "ParameterizedSingleTest(True)", true, false, false, false),
+            Tuple(TESTCASE_AFTER, "ParameterizedSingleTest(True)", true, false, false, false),
+            Tuple(TESTCASE_AFTER, "ParameterizedSingleTest", true, false, false, false),
             // test suite is failing
             Tuple(TESTSUITE_AFTER, "After", false, false, true, false)
         );

--- a/test/src/core/GdUnitTestSuiteBuilderTest.cs
+++ b/test/src/core/GdUnitTestSuiteBuilderTest.cs
@@ -236,6 +236,8 @@ public class GdUnitTestSuiteBuilderTest
                 Tuple("TestCasesWithCustomTestName", 64, new List<string> {
                     "TestCaseA(1, 2, 3, 6)",
                     "TestCaseB(3, 4, 5, 12)",
-                    "TestCaseC(6, 7, 8, 21)" }));
+                    "TestCaseC(6, 7, 8, 21)" }),
+                Tuple("ParameterizedSingleTest", 72, new List<string> {
+                    "ParameterizedSingleTest(True)" }));
     }
 }

--- a/test/src/core/resources/testsuites/mono/TestSuiteParameterizedTests.cs
+++ b/test/src/core/resources/testsuites/mono/TestSuiteParameterizedTests.cs
@@ -23,4 +23,8 @@ public class TestSuiteParameterizedTests
     [TestCase(6, 7, 8, 22)]
     public void ParameterizedIntValuesFail(int a, int b, int c, int expected)
         => AssertThat(a + b + c).IsEqual(expected);
+
+    [TestCase(true)]
+    public void ParameterizedSingleTest(bool value)
+        => AssertThat(value).IsTrue();
 }


### PR DESCRIPTION
# Why
https://github.com/MikeSchulze/gdUnit4Net/issues/96

# What
There was a wrong check to switch between single and parameterized tests. Added a more intuitive test case parameter to verify if a test is parameterized