### PR TITLE
GD-103: Trim MSTest assert stack trace

### DIFF
--- a/PackageVersions.props
+++ b/PackageVersions.props
@@ -5,7 +5,7 @@
     <MicrosoftSdkVersion>17.9.0</MicrosoftSdkVersion>
     <MicrosoftCodeAnalysisCSharpVersion>4.9.2</MicrosoftCodeAnalysisCSharpVersion>
     <MoqVersion>4.18.4</MoqVersion>
-    <GdUnitAPIVersion>4.2.4-rc2</GdUnitAPIVersion>
+    <GdUnitAPIVersion>4.2.4-rc3</GdUnitAPIVersion>
     <GdUnitTestAdapterVersion>1.1.1</GdUnitTestAdapterVersion>
   </PropertyGroup>
 </Project>

--- a/test/gdUnit4Test.csproj
+++ b/test/gdUnit4Test.csproj
@@ -26,6 +26,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftSdkVersion)" />
+    <!-- We only include here the MSTest framework to run tests mixed with MSTest assertions-->
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <ProjectReference Include="..\api\gdUnit4Api.csproj" />
     <ProjectReference Include="..\testadapter\gdUnit4TestAdapter.csproj" />
   </ItemGroup>


### PR DESCRIPTION
# Why
https://github.com/MikeSchulze/gdUnit4Net/issues/103

# What
- do filter all stack frames out containing `Microsoft.VisualStudio.TestTools`

![image](https://github.com/MikeSchulze/gdUnit4Net/assets/347037/4925aae0-6a05-4233-8bc3-112745ef7bfe)
changes to:
![image](https://github.com/MikeSchulze/gdUnit4Net/assets/347037/4bda47e2-9b45-4161-ad6a-630e73cca251)

