### PR TITLE
GD-104: Fix exception failure message propagation

### DIFF
--- a/api/src/core/execution/TestSuiteExecutionStage.cs
+++ b/api/src/core/execution/TestSuiteExecutionStage.cs
@@ -1,7 +1,6 @@
 namespace GdUnit4.Executions;
 
 using System.Threading.Tasks;
-using System.Linq;
 
 internal sealed class TestSuiteExecutionStage : IExecutionStage
 {

--- a/test/.runsettings
+++ b/test/.runsettings
@@ -7,6 +7,9 @@
         <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
         <TestSessionTimeout>300000</TestSessionTimeout>
         <TreatNoTestsAsError>true</TreatNoTestsAsError>
+        <EnvironmentVariables>
+            <GODOT_BIN>d:\development\Godot_v4.2.1-stable_mono_win64\Godot_v4.2.1-stable_mono_win64.exe</GODOT_BIN>
+        </EnvironmentVariables>
     </RunConfiguration>
 
     <LoggerRunSettings>

--- a/test/src/core/ExecutorTest.cs
+++ b/test/src/core/ExecutorTest.cs
@@ -728,4 +728,53 @@ public class ExecutorTest : ITestEventListener
             Tuple(TESTSUITE_AFTER, "After", new List<TestReport>())
         );
     }
+
+    [TestCase(Description = "Verifies the exceptions are catches the right message as failure.")]
+    public async Task ExecuteTestWithExceptions()
+    {
+        var testSuite = LoadTestSuite("src/core/resources/testsuites/mono/TestSuiteAllTestsFailWithExceptions.cs");
+        AssertArray(testSuite.TestCases).Extract("Name").ContainsExactly(new string[] { "ExceptionIsThrownOnSceneInvoke", "ExceptionAtAsyncMethod", "ExceptionAtSyncMethod" });
+
+        var events = await ExecuteTestSuite(testSuite);
+
+        AssertTestCaseNames(events)
+            .ContainsExactly(ExpectedEvents("TestSuiteAllTestsFailWithExceptions", "ExceptionIsThrownOnSceneInvoke", "ExceptionAtAsyncMethod", "ExceptionAtSyncMethod"));
+
+        // we expect all tests are failing and commits failures
+        AssertEventCounters(events).ContainsExactly(
+            Tuple(TESTSUITE_BEFORE, "Before", 0, 0, 0),
+            Tuple(TESTCASE_BEFORE, "ExceptionIsThrownOnSceneInvoke", 0, 0, 0),
+            Tuple(TESTCASE_AFTER, "ExceptionIsThrownOnSceneInvoke", 0, 1, 0),
+            Tuple(TESTCASE_BEFORE, "ExceptionAtAsyncMethod", 0, 0, 0),
+            Tuple(TESTCASE_AFTER, "ExceptionAtAsyncMethod", 0, 1, 0),
+            Tuple(TESTCASE_BEFORE, "ExceptionAtSyncMethod", 0, 0, 0),
+            Tuple(TESTCASE_AFTER, "ExceptionAtSyncMethod", 0, 1, 0),
+            Tuple(TESTSUITE_AFTER, "After", 0, 0, 0)
+        );
+        AssertEventStates(events).ContainsExactly(
+            Tuple(TESTSUITE_BEFORE, "Before", true, false, false, false),
+            Tuple(TESTCASE_BEFORE, "ExceptionIsThrownOnSceneInvoke", true, false, false, false),
+            Tuple(TESTCASE_AFTER, "ExceptionIsThrownOnSceneInvoke", false, false, true, false),
+            Tuple(TESTCASE_BEFORE, "ExceptionAtAsyncMethod", true, false, false, false),
+            Tuple(TESTCASE_AFTER, "ExceptionAtAsyncMethod", false, false, true, false),
+            Tuple(TESTCASE_BEFORE, "ExceptionAtSyncMethod", true, false, false, false),
+            Tuple(TESTCASE_AFTER, "ExceptionAtSyncMethod", false, false, true, false),
+            // report suite is not success, is failed
+            Tuple(TESTSUITE_AFTER, "After", false, false, true, false)
+        );
+        // check for failure reports
+        AssertReports(events).Contains(
+            Tuple(TESTSUITE_BEFORE, "Before", new List<TestReport>()),
+            Tuple(TESTCASE_AFTER, "ExceptionIsThrownOnSceneInvoke", new List<TestReport>() { new(FAILURE, 12, """
+                Test Exception
+                """) }),
+            Tuple(TESTCASE_AFTER, "ExceptionAtAsyncMethod", new List<TestReport>() { new(FAILURE, 24, """
+                outer exception
+                """) }),
+            Tuple(TESTCASE_AFTER, "ExceptionAtSyncMethod", new List<TestReport>() { new(FAILURE, 28, """
+                outer exception
+                """) }),
+            Tuple(TESTSUITE_AFTER, "After", new List<TestReport>()));
+    }
+
 }

--- a/test/src/core/resources/testsuites/mono/TestSuiteAllTestsFailWithExceptions.cs
+++ b/test/src/core/resources/testsuites/mono/TestSuiteAllTestsFailWithExceptions.cs
@@ -1,0 +1,30 @@
+namespace GdUnit4.Tests.Core;
+
+using System;
+using System.Threading.Tasks;
+
+
+// will be ignored because of missing `[TestSuite]` annotation
+// used by executor integration test
+public class TestSuiteAllTestsFailWithExceptions
+{
+
+    [TestCase]
+    public void ExceptionIsThrownOnSceneInvoke()
+    {
+        var runner = ISceneRunner.Load("res://src/core/resources/scenes/TestSceneWithExceptionTest.tscn");
+
+        runner.Invoke("SomeMethodThatThrowsException");
+    }
+
+    [TestCase]
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+    public async Task ExceptionAtAsyncMethod()
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        => throw new ArgumentException("outer exception", new ArgumentNullException("inner exception"));
+
+    [TestCase]
+    public void ExceptionAtSyncMethod()
+        => throw new ArgumentException("outer exception", new ArgumentNullException("inner exception"));
+
+}


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4Net/issues/106

# What
fixing the extraction of inner exception to catch the right exception message