### PR TITLE
GD-110: Allow a Node to be passed in to SceneRunner.Load as the root of the scene.

### DIFF
--- a/api/src/ISceneRunner.cs
+++ b/api/src/ISceneRunner.cs
@@ -1,7 +1,6 @@
 namespace GdUnit4;
 
 using System;
-using System.IO;
 using System.Threading.Tasks;
 
 using Godot;

--- a/api/src/ISceneRunner.cs
+++ b/api/src/ISceneRunner.cs
@@ -1,6 +1,7 @@
 namespace GdUnit4;
 
 using System;
+using System.IO;
 using System.Threading.Tasks;
 
 using Godot;
@@ -33,7 +34,19 @@ public interface ISceneRunner : IDisposable
     /// <param name="autofree">If true the loaded scene will be automatic freed when the runner is freed.</param>
     /// <param name="verbose">Prints detailed infos on scene simulation.</param>
     /// <returns></returns>
-    public static ISceneRunner Load(string resourcePath, bool autofree = false, bool verbose = false) => new Core.SceneRunner(resourcePath, autofree, verbose);
+    public static ISceneRunner Load(string resourcePath, bool autofree = false, bool verbose = false)
+    {
+        if (!ResourceLoader.Exists(resourcePath))
+            throw new FileNotFoundException($"GdUnitSceneRunner: Can't load scene by given resource path: '{resourcePath}'. The resource does not exists.");
+        if (!resourcePath.EndsWith(".tscn") && !resourcePath.EndsWith(".scn") && !resourcePath.StartsWith("uid://"))
+            throw new ArgumentException($"GdUnitSceneRunner: The given resource: '{resourcePath}' is not a scene.");
+
+        var currentScene = ((PackedScene)ResourceLoader.Load(resourcePath)).Instantiate();
+
+        return Load(currentScene, autofree, verbose);
+    }
+
+    public static ISceneRunner Load(Node currentScene, bool autofree = false, bool verbose = false) => new Core.SceneRunner(currentScene, autofree, verbose);
 
 
     /// <summary>

--- a/api/src/ISceneRunner.cs
+++ b/api/src/ISceneRunner.cs
@@ -34,17 +34,7 @@ public interface ISceneRunner : IDisposable
     /// <param name="autofree">If true the loaded scene will be automatic freed when the runner is freed.</param>
     /// <param name="verbose">Prints detailed infos on scene simulation.</param>
     /// <returns></returns>
-    public static ISceneRunner Load(string resourcePath, bool autofree = false, bool verbose = false)
-    {
-        if (!ResourceLoader.Exists(resourcePath))
-            throw new FileNotFoundException($"GdUnitSceneRunner: Can't load scene by given resource path: '{resourcePath}'. The resource does not exists.");
-        if (!resourcePath.EndsWith(".tscn") && !resourcePath.EndsWith(".scn") && !resourcePath.StartsWith("uid://"))
-            throw new ArgumentException($"GdUnitSceneRunner: The given resource: '{resourcePath}' is not a scene.");
-
-        var currentScene = ((PackedScene)ResourceLoader.Load(resourcePath)).Instantiate();
-
-        return Load(currentScene, autofree, verbose);
-    }
+    public static ISceneRunner Load(string resourcePath, bool autofree = false, bool verbose = false) => new Core.SceneRunner(resourcePath, autofree, verbose);
 
     public static ISceneRunner Load(Node currentScene, bool autofree = false, bool verbose = false) => new Core.SceneRunner(currentScene, autofree, verbose);
 

--- a/api/src/core/SceneRunner.cs
+++ b/api/src/core/SceneRunner.cs
@@ -2,7 +2,6 @@ namespace GdUnit4.Core;
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Reflection;
@@ -61,17 +60,13 @@ internal sealed class SceneRunner : ISceneRunner
     private readonly ICollection<Key> keyOnPress = new HashSet<Key>();
     private readonly ICollection<MouseButton> mouseButtonOnPress = new HashSet<MouseButton>();
 
-    public SceneRunner(string resourcePath, bool autoFree = false, bool verbose = false)
+    public SceneRunner(Node currentScene, bool autoFree = false, bool verbose = false)
     {
-        if (!ResourceLoader.Exists(resourcePath))
-            throw new FileNotFoundException($"GdUnitSceneRunner: Can't load scene by given resource path: '{resourcePath}'. The resource does not exists.");
         Verbose = verbose;
         SceneAutoFree = autoFree;
         Executions.ExecutionContext.RegisterDisposable(this);
         SceneTree = (SceneTree)Engine.GetMainLoop();
-        if (!resourcePath.EndsWith(".tscn") && !resourcePath.EndsWith(".scn") && !resourcePath.StartsWith("uid://"))
-            throw new ArgumentException($"GdUnitSceneRunner: The given resource: '{resourcePath}' is not a scene.");
-        CurrentScene = ((PackedScene)ResourceLoader.Load(resourcePath)).Instantiate();
+        CurrentScene = currentScene;
         SceneTree.Root.AddChild(CurrentScene);
         SavedIterationsPerSecond = Engine.PhysicsTicksPerSecond;
         SetTimeFactor(1.0);

--- a/api/src/core/SceneRunner.cs
+++ b/api/src/core/SceneRunner.cs
@@ -2,6 +2,7 @@ namespace GdUnit4.Core;
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Reflection;
@@ -59,6 +60,21 @@ internal sealed class SceneRunner : ISceneRunner
     private readonly ICollection<string> actionOnPress = new HashSet<string>();
     private readonly ICollection<Key> keyOnPress = new HashSet<Key>();
     private readonly ICollection<MouseButton> mouseButtonOnPress = new HashSet<MouseButton>();
+
+    public SceneRunner(string resourcePath, bool autoFree = false, bool verbose = false) : this(LoadScene(resourcePath), autoFree, verbose)
+    {
+    }
+
+    private static Node LoadScene(string resourcePath)
+    {
+        if (!ResourceLoader.Exists(resourcePath))
+            throw new FileNotFoundException($"GdUnitSceneRunner: Can't load scene by given resource path: '{resourcePath}'. The resource does not exists.");
+        if (!resourcePath.EndsWith(".tscn") && !resourcePath.EndsWith(".scn") && !resourcePath.StartsWith("uid://"))
+            throw new ArgumentException($"GdUnitSceneRunner: The given resource: '{resourcePath}' is not a scene.");
+
+        return ((PackedScene)ResourceLoader.Load(resourcePath)).Instantiate();
+    }
+
 
     public SceneRunner(Node currentScene, bool autoFree = false, bool verbose = false)
     {

--- a/test/gdUnit4Test.csproj
+++ b/test/gdUnit4Test.csproj
@@ -29,7 +29,6 @@
     <!-- We only include here the MSTest framework to run tests mixed with MSTest assertions-->
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <ProjectReference Include="..\api\gdUnit4Api.csproj" />
-    <ProjectReference Include="..\testadapter\gdUnit4TestAdapter.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/gdUnit4Test.csproj
+++ b/test/gdUnit4Test.csproj
@@ -29,9 +29,6 @@
     <!-- We only include here the MSTest framework to run tests mixed with MSTest assertions-->
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <ProjectReference Include="..\api\gdUnit4Api.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="src\core\resources\scenes\TestSceneWithInitialization.tscn" />
+    <ProjectReference Include="..\testadapter\gdUnit4TestAdapter.csproj" />
   </ItemGroup>
 </Project>

--- a/test/gdUnit4Test.csproj
+++ b/test/gdUnit4Test.csproj
@@ -31,4 +31,8 @@
     <ProjectReference Include="..\api\gdUnit4Api.csproj" />
     <ProjectReference Include="..\testadapter\gdUnit4TestAdapter.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="src\core\resources\scenes\TestSceneWithInitialization.tscn" />
+  </ItemGroup>
 </Project>

--- a/test/src/core/SceneRunnerCSharpSceneTest.cs
+++ b/test/src/core/SceneRunnerCSharpSceneTest.cs
@@ -3,6 +3,8 @@ namespace GdUnit4.Tests.Core;
 using System.IO;
 using System.Threading.Tasks;
 
+using core.resources.scenes;
+
 using Godot;
 
 using static Assertions;
@@ -73,13 +75,24 @@ public sealed class SceneRunnerCSharpSceneTest
 
 
     [TestCase]
-    public void LoadSceneNode()
+    public void InitializeSceneBeforeAddingToSceneTree()
     {
-        var currentScene = new Node();
+        var currentScene = ((PackedScene)ResourceLoader.Load("res://src/core/resources/scenes/TestSceneWithInitialization.tscn")).Instantiate<TestSceneWithInitialization>();
+
+        currentScene.Initialize();
+
+        AssertThat(currentScene.MethodCalls.Count).IsEqual(1);
+        AssertThat(currentScene.MethodCalls[0]).IsEqual("Initialize");
+
         using var runner = ISceneRunner.Load(currentScene, true);
         AssertThat(runner.Scene())
-            .IsInstanceOf<Node>()
+            .IsInstanceOf<TestSceneWithInitialization>()
             .IsSame(currentScene);
+
+        var actualScene = ((TestSceneWithInitialization)runner.Scene());
+        AssertThat(actualScene.MethodCalls.Count).IsEqual(2);
+        AssertThat(actualScene.MethodCalls[0]).IsEqual("Initialize");
+        AssertThat(actualScene.MethodCalls[1]).IsEqual("_Ready");
     }
 
     [TestCase]

--- a/test/src/core/SceneRunnerCSharpSceneTest.cs
+++ b/test/src/core/SceneRunnerCSharpSceneTest.cs
@@ -71,6 +71,16 @@ public sealed class SceneRunnerCSharpSceneTest
             .IsNotNull();
     }
 
+
+    [TestCase]
+    public void LoadSceneNode()
+    {
+        using var runner = ISceneRunner.Load(new Node(), true);
+        AssertThat(runner.Scene())
+            .IsInstanceOf<Node>()
+            .IsNotNull();
+    }
+
     [TestCase]
     public void GetProperty()
     {

--- a/test/src/core/SceneRunnerCSharpSceneTest.cs
+++ b/test/src/core/SceneRunnerCSharpSceneTest.cs
@@ -75,10 +75,11 @@ public sealed class SceneRunnerCSharpSceneTest
     [TestCase]
     public void LoadSceneNode()
     {
-        using var runner = ISceneRunner.Load(new Node(), true);
+        var currentScene = new Node();
+        using var runner = ISceneRunner.Load(currentScene, true);
         AssertThat(runner.Scene())
             .IsInstanceOf<Node>()
-            .IsNotNull();
+            .IsSame(currentScene);
     }
 
     [TestCase]

--- a/test/src/core/resources/scenes/TestSceneWithInitialization.cs
+++ b/test/src/core/resources/scenes/TestSceneWithInitialization.cs
@@ -1,0 +1,15 @@
+using Godot;
+
+namespace GdUnit4.Tests.core.resources.scenes;
+
+using System.Collections.Generic;
+
+public partial class TestSceneWithInitialization : Node2D
+{
+    private readonly List<string> methodCalls = new();
+    public List<string> MethodCalls => methodCalls;
+    public void Initialize() => methodCalls.Add("Initialize");
+
+    public override void _Ready() => methodCalls.Add("_Ready");
+}
+

--- a/test/src/core/resources/scenes/TestSceneWithInitialization.tscn
+++ b/test/src/core/resources/scenes/TestSceneWithInitialization.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://b4d0favbx8ckg"]
+
+[ext_resource type="Script" path="res://src/core/resources/scenes/TestSceneWithInitialization.cs" id="1"]
+
+[node name="SceneWithInitialization" type="Node2D"]
+script = ExtResource("1")


### PR DESCRIPTION
### Why
[GD-110](https://github.com/MikeSchulze/gdUnit4Net/issues/110)

### What
- Added overloaded ISceneRunner.Load that accepts a Node
- Pulled scene loading logic out of the SceneRunner constructor and into the ISceneRunner.Load method

### Example Usage
Tests can now initialize or use the root node of a scene before it is loaded and any _Ready functions are called on it.

Ex.
```
public partial class MyNode : Node2d
{ 
    public void Initialize(int foo) { ... }
}

[TestSuite]
public class MyNodeTest  
{ 

    [TestCase]
    public void  MyNodeInitTest()
    {
      var myNode = new MyNode();
      myNode.Initialize(12);
      var sceneRunner = ISceneRunner.Load(myNode);
      
      ...
    }
}
```
