### PR TITLE
GD-114: Fix test adapter `gdUnit4.api` version resolving

### DIFF
--- a/testadapter/src/utilities/Utils.cs
+++ b/testadapter/src/utilities/Utils.cs
@@ -11,13 +11,8 @@ internal static class Utils
 
     internal static bool CheckGdUnit4ApiVersion(IMessageLogger logger, Version minVersion)
     {
-        var dependencies = Assembly
-            .GetExecutingAssembly()
-            .GetReferencedAssemblies()
-            .Where(assemblyName => "gdUnit4Api".Equals(assemblyName.Name, StringComparison.Ordinal));
-        if (!dependencies.Any())
-            throw new InvalidOperationException($"No 'gdUnit4Api' is installed!");
-        var version = dependencies.First().Version;
+        var gdUnit4ApiAssembly = Assembly.Load("gdUnit4Api") ?? throw new InvalidOperationException($"No 'gdUnit4Api' is installed!");
+        var version = gdUnit4ApiAssembly.GetName().Version;
         logger.SendMessage(TestMessageLevel.Informational, $"CheckGdUnit4ApiVersion gdUnit4Api, Version={version}");
         if (version < minVersion)
         {


### PR DESCRIPTION
# Why
The test adapter shows the wrong version in the output logs, the statically bound version was used.

# What
- We now load the assembly and extract the version
