### PR TITLE
GD-116:  Add publish WF to publish test reports in a separate way

### DIFF
--- a/.github/actions/upload-test-report/action.yml
+++ b/.github/actions/upload-test-report/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         retention-days: 10
-        name: ${{ inputs.report-name }}
+        name: artifact_${{ inputs.report-name }}
         path: |
           ./test/TestResults/test-result.trx
           ./test/reports/**

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -1,0 +1,77 @@
+name: 'Publish Test Report'
+on:
+  workflow_run:
+    workflows: ['ci-pr']  # runs after ci-pr workflow
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      workflow_run_id:
+        description: 'ID of the workflow run to download artifacts from.'
+        required: true
+        default: ''
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  publish-reports:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        godot-version: ['4.2', '4.2.1', '4.2.2']
+        godot-status: ['stable']
+        include:
+          - godot-version: '4.3'
+            godot-status: 'dev6'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+
+      # publish Run gdUnit4-action results
+      - name: Download action tests artifacts
+        uses: actions/download-artifact@v4.1.7
+        with:
+          name: artifact_action_example_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: MikeSchulze/gdUnit4Net
+          run-id: ${{ github.event.inputs.workflow_run_id || github.event.workflow_run.id }}
+
+      - name: Publish action Test Results
+        uses: dorny/test-reporter@v1.9.1
+        with:
+          name: report_action_example_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}
+          # using artifact to download is broken since download-artifact@v4 see https://github.com/dorny/test-reporter/issues/363
+          # We do the download manually on step `Download artifacts`
+          #artifact: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
+          path: './home/runner/work/gdUnit4Net/gdUnit4Net/example/reports/*.xml'
+          reporter: dotnet-trx
+          fail-on-error: 'false'
+          fail-on-empty: 'false'
+
+      # publish API Tests results
+      - name: Download API tests artifacts
+        uses: actions/download-artifact@v4.1.7
+        with:
+          name: artifact_api_tests_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: MikeSchulze/gdUnit4Net
+          run-id: ${{ github.event.inputs.workflow_run_id || github.event.workflow_run.id }}
+
+      - name: Publish API Test Results
+        uses: dorny/test-reporter@v1.9.1
+        with:
+          name: report_api_tests_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}
+          # using artifact to download is broken since download-artifact@v4 see https://github.com/dorny/test-reporter/issues/363
+          # We do the download manually on step `Download artifacts`
+          #artifact: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
+          path: './home/runner/work/gdUnit4Net/gdUnit4Net/test/reports/*.xml'
+          reporter: dotnet-trx
+          fail-on-error: 'false'
+          fail-on-empty: 'false'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,12 +49,12 @@ jobs:
           lfs: true
 
        # the vstest filter is actual not implemented and the argument 'paths' on gdUnit4-action@v1.0.8 will have no affect
-      - name: 'Temp solutuon, we delete the failing test for now.'
+      - name: 'Temp solution, we delete the failing test for now.'
         shell: bash
         run: |
           rm -rf ./example/test/ExampleTest.cs
 
-      - name: 'Test GdUnit4 - Godot_${{ inputs.godot-version }}-${{ inputs.godot-status }}-net'
+      - name: 'Test Example via gdunit-action - Godot_${{ inputs.godot-version }}-${{ inputs.godot-status }}-net'
         uses: MikeSchulze/gdUnit4-action@v1.0.8
         with:
           godot-version: ${{ inputs.godot-version }}
@@ -67,15 +67,13 @@ jobs:
           timeout: 2
           retries: 3 # We have set the number of repetitions to 3 because Godot mono randomly crashes during C# tests
           publish-report: false
-          report-name: gdUnit4Action-${{ inputs.godot-version }}-${{ inputs.godot-status }}
+          report-name: 'action_example_Godot${{ inputs.godot-version }}-${{ inputs.godot-status }}'
 
 
   unit-test-adapter:
     name: "Run API Tests"
     runs-on: ${{ inputs.os }}
     timeout-minutes: 5
-    env:
-      REPORT_NAME: "Report_API_Tests-${{ inputs.godot-version }}-${{ inputs.godot-status }}"
 
     steps:
       - uses: actions/checkout@v4
@@ -93,7 +91,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
 
       - name: "Compile C#"
         if: ${{ !cancelled() }}
@@ -113,25 +111,16 @@ jobs:
           $GODOT_BIN --path ./test --headless --build-solutions --quit-after 20
           xvfb-run --auto-servernum dotnet test ./test/gdUnit4Test.csproj --no-build --settings ./test/.runsettings-ci
 
-      - name: "Publish Unit Test Reports"
-        if: ${{ !cancelled() }}
-        uses: ./.github/actions/publish-test-report
-        with:
-          report-name: ${{ env.REPORT_NAME }}
-          report-path: './test/TestResults/test-result.trx'
-
       - name: "Upload Unit Test Reports"
         if: ${{ !cancelled() }}
         uses: ./.github/actions/upload-test-report
         with:
-          report-name: ${{ env.REPORT_NAME }}
+          report-name: api_tests_Godot${{ inputs.godot-version }}-${{ inputs.godot-status }}
 
   unit-test-example:
     name: "Run Test Examples"
     runs-on: ${{ inputs.os }}
     timeout-minutes: 3
-    env:
-      REPORT_NAME: "Report_Examples-${{ inputs.godot-version }}-${{ inputs.godot-status }}"
 
     steps:
       - uses: actions/checkout@v4
@@ -149,7 +138,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
 
       - name: "Compile C#"
         if: ${{ !cancelled() }}
@@ -196,16 +185,3 @@ jobs:
           validate_section '<ResultSummary' '<ResultSummary outcome="Failed">'
           validate_section '<ResultSummary' '<Counters total="11" executed="11" passed="10" failed="1" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />'
           echo "All tests passes."
-
-      - name: "Publish Unit Test Reports"
-        if: ${{ !cancelled() }}
-        uses: ./.github/actions/publish-test-report
-        with:
-          report-name: ${{ env.REPORT_NAME }}
-          report-path: './example/TestResults/test-result.trx'
-
-      - name: "Upload Unit Test Reports"
-        if: ${{ !cancelled() }}
-        uses: ./.github/actions/upload-test-report
-        with:
-          report-name: ${{ env.REPORT_NAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Project-specific ignores
 .history
+.idea
 .godot
 obj/
 nupkg/*

--- a/test/.runsettings
+++ b/test/.runsettings
@@ -37,9 +37,9 @@
     </TestRunParameters>
 
     <GdUnit4>
-        <!-- Additonal Godot runtime parameters-->
+        <!-- Additional Godot runtime parameters-->
         <Parameters>--verbose</Parameters>
-        <!-- Controlls the Display name attribute of the TestCase. Allowed values are SimpleName and FullyQualifiedName.
+        <!-- Controls the Display name attribute of the TestCase. Allowed values are SimpleName and FullyQualifiedName.
              This likely determines how the test names are displayed in the test results.-->
         <DisplayName>FullyQualifiedName</DisplayName>
     </GdUnit4>

--- a/test/.runsettings-ci
+++ b/test/.runsettings-ci
@@ -46,10 +46,10 @@
     </DataCollectionRunSettings>
 
     <GdUnit4>
-        <!-- Additonal Godot runtime parameters-->
+        <!-- Additional Godot runtime parameters-->
         <!-- These parameters are crucial for configuring the Godot runtime to work in headless environments, such as those used in automated testing or CI/CD pipelines.-->
         <Parameters>--audio-driver Dummy --display-driver x11 --rendering-driver opengl3 --screen 0 --verbose</Parameters>
-        <!-- Controlls the Display name attribute of the TestCase. Allowed values are SimpleName and FullyQualifiedName.
+        <!-- Controls the Display name attribute of the TestCase. Allowed values are SimpleName and FullyQualifiedName.
              This likely determines how the test names are displayed in the test results.-->
         <DisplayName>FullyQualifiedName</DisplayName>
     </GdUnit4>


### PR DESCRIPTION
# Why
See https://github.com/MikeSchulze/gdUnit4Net/issues/116

# What
- removed the publish steps from the unit test WF and do only upload the test artifacts
- add seperate WF to download the test artifacts and publish it afterwards