### PR TITLE
GD-121: Improve `AssertSignal` by adding a `StartMonitoring` method

### DIFF
--- a/api/src/Assertions.cs
+++ b/api/src/Assertions.cs
@@ -65,7 +65,7 @@ public sealed class Assertions
     /// <typeparam name="TValue">The type of Godot vector.</typeparam>
     /// <param name="vector">The vector value to verify.</param>
     /// <returns>An instance of IVectorAssert for further assertions.</returns>
-    public static IVectorAssert<TValue> AssertVector<TValue>(TValue vector) where TValue : notnull, IEquatable<TValue>
+    public static IVectorAssert<TValue> AssertVector<TValue>(TValue vector) where TValue : IEquatable<TValue>
         => new VectorAssert<TValue>(vector);
 
     /// <summary>
@@ -118,12 +118,6 @@ public sealed class Assertions
     public static INumberAssert<double> AssertThat(double current) => new NumberAssert<double>(current);
     public static INumberAssert<decimal> AssertThat(decimal current) => new NumberAssert<decimal>(current);
 
-    /**
-        public static IDictionaryAssert<TKey, TValue> AssertThat<TKey, TValue>(IDictionary? current)
-            where TKey : notnull
-            where TValue : notnull
-            => new DictionaryAssert<TKey, TValue>(current);
-*/
     public static IDictionaryAssert<TKey, TValue> AssertThat<TKey, TValue>(IDictionary<TKey, TValue>? current)
         where TKey : notnull
         where TValue : notnull

--- a/api/src/ISignalAssert.cs
+++ b/api/src/ISignalAssert.cs
@@ -5,6 +5,15 @@ using System.Threading.Tasks;
 /// <summary> An Assertion Tool to verify Godot signals</summary>
 public interface ISignalAssert : IAssertBase<Godot.GodotObject>
 {
+
+    /// <summary>
+    /// Starts the monitoring of emitted signals during the test runtime.
+    /// It should be called first if you want to collect all emitted signals after the emitter has been created.
+    /// </summary>
+    /// <returns></returns>
+    public ISignalAssert StartMonitoring();
+
+
     /// <summary>
     /// Verifies that given signal is emitted until waiting time
     /// </summary>

--- a/api/src/asserts/SignalAssert.cs
+++ b/api/src/asserts/SignalAssert.cs
@@ -7,10 +7,14 @@ using System.Threading.Tasks;
 using Exceptions;
 using Core.Signals;
 
-internal sealed partial class SignalAssert : AssertBase<Godot.GodotObject>, ISignalAssert
+internal sealed class SignalAssert : AssertBase<Godot.GodotObject>, ISignalAssert
 {
     public SignalAssert(Godot.GodotObject current) : base(current)
         => GodotSignalCollector.Instance.RegisterEmitter(current);
+
+    // Is just a dummy method that is called to register the monitor on the emitter, which is done in the constructor
+    public ISignalAssert StartMonitoring()
+        => this;
 
     public async Task<ISignalAssert> IsEmitted(string signal, params Godot.Variant[] args)
     {

--- a/api/src/core/signals/GodotSignalCollector.cs
+++ b/api/src/core/signals/GodotSignalCollector.cs
@@ -5,12 +5,13 @@ using static System.Console;
 using System;
 using System.Threading;
 using System.Collections.Generic;
+using System.Linq;
 
-internal sealed partial class GodotSignalCollector : Godot.RefCounted, IDisposable
+internal sealed partial class GodotSignalCollector : Godot.RefCounted
 {
     private readonly Dictionary<Godot.GodotObject, Dictionary<string, List<Godot.Variant[]>>> collectedSignals = new();
 
-    public static GodotSignalCollector Instance { get; } = new GodotSignalCollector();
+    public static GodotSignalCollector Instance { get; } = new();
 
     public void RegisterEmitter(Godot.GodotObject emitter)
     {
@@ -19,7 +20,7 @@ internal sealed partial class GodotSignalCollector : Godot.RefCounted, IDisposab
             return;
         collectedSignals[emitter] = new Dictionary<string, List<Godot.Variant[]>>();
         // connect to 'TreeExiting' of the emitter to finally release all acquired resources/connections.
-        Action<GodotSignalCollector, Godot.GodotObject> action = UnregisterEmitter;
+        var action = UnregisterEmitter;
         if (!emitter.IsConnected(Godot.Node.SignalName.TreeExiting, Godot.Callable.From(action)))
             ((Godot.Node)emitter).TreeExiting += () => UnregisterEmitter(this, emitter);
 
@@ -60,15 +61,14 @@ internal sealed partial class GodotSignalCollector : Godot.RefCounted, IDisposab
             collectedSignals[emitter][signalName].Add(signalArgs);
     }
 
-    private bool IsSignalCollecting(Godot.GodotObject emitter, string signalName) =>
-        collectedSignals.ContainsKey(emitter) && collectedSignals[emitter].ContainsKey(signalName);
+    internal bool IsSignalCollecting(Godot.GodotObject emitter, string signalName)
+        => collectedSignals.ContainsKey(emitter) && collectedSignals[emitter].ContainsKey(signalName);
 
     // unregister all acquired resources/connections, otherwise it ends up in orphans
     // is called when the emitter is removed from the parent
-    public void UnregisterEmitter(GodotSignalCollector collector, Godot.GodotObject emitter)
+    private void UnregisterEmitter(GodotSignalCollector collector, Godot.GodotObject emitter)
     {
         if (IsInstanceValid(collector))
-        {
             //WriteLine($"disconnect_signals: {emitter}");
             foreach (var connection in collector.GetIncomingConnections())
             {
@@ -76,9 +76,8 @@ internal sealed partial class GodotSignalCollector : Godot.RefCounted, IDisposab
                 var signalName = (string)connection["signal_name"];
                 var methodName = (string)connection["method_name"];
                 //WriteLine($"disconnect: {signalName} from {source} target {collector} -> {methodName}");
-                source!.Disconnect(signalName, new Godot.Callable(collector, methodName));
+                source.Disconnect(signalName, new Godot.Callable(collector, methodName));
             }
-        }
         if (IsInstanceValid(emitter))
             collectedSignals.Remove(emitter);
         //DebugSignalList("UnregisterEmitter");
@@ -87,39 +86,27 @@ internal sealed partial class GodotSignalCollector : Godot.RefCounted, IDisposab
     private void ResetCollectedSignals(Godot.GodotObject emitter)
     {
         //DebugSignalList("before clear");
-#pragma warning disable CA1854
-        if (collectedSignals.ContainsKey(emitter))
-            foreach (var signalName in collectedSignals[emitter].Keys)
-                collectedSignals[emitter][signalName].Clear();
-#pragma warning restore CA1854
+        if (!collectedSignals.TryGetValue(emitter, out var value)) return;
+        foreach (var signalName in value.Keys)
+            value[signalName].Clear();
         //DebugSignalList("after clear");
     }
 
     private bool Match(Godot.GodotObject emitter, string signalName, params Godot.Variant[] args)
-    {
         //DebugSignalList("--match--");
-        foreach (var receivedArgs in collectedSignals[emitter][signalName])
-        {
-            if (receivedArgs.VariantEquals(args))
-                return true;
-        }
-        return false;
-    }
+        => collectedSignals[emitter][signalName].Any(receivedArgs => receivedArgs.VariantEquals(args));
 
     private void DebugSignalList(string message)
     {
         WriteLine($"-----{message}-------");
         WriteLine("senders {");
-        foreach (var emitter in collectedSignals.Keys)
+        foreach (var emitter in collectedSignals.Keys.Where(IsInstanceValid))
         {
-            if (IsInstanceValid(emitter))
+            WriteLine($"\t{emitter}");
+            foreach (var signalName in collectedSignals[emitter].Keys)
             {
-                WriteLine($"\t{emitter}");
-                foreach (var signalName in collectedSignals[emitter].Keys)
-                {
-                    var args = collectedSignals[emitter][signalName];
-                    WriteLine($"\t\t{signalName} {args.Formatted()}");
-                }
+                var args = collectedSignals[emitter][signalName];
+                WriteLine($"\t\t{signalName} {args.Formatted()}");
             }
         }
         WriteLine("}");
@@ -129,21 +116,19 @@ internal sealed partial class GodotSignalCollector : Godot.RefCounted, IDisposab
     {
         try
         {
-            var node = emitter;
-            var isProcess = node?.HasMethod("_Process") ?? false;
-            var isPhysicsProcess = node?.HasMethod("_PhysicsProcess") ?? false;
+            var isProcess = emitter.HasMethod("_Process");
+            var isPhysicsProcess = emitter.HasMethod("_PhysicsProcess");
             var sleepTimeInMs = 10;
             while (!Match(emitter, signal, args))
             {
                 Thread.Sleep(sleepTimeInMs);
                 if (isProcess)
-                    node!.CallDeferred("_Process", sleepTimeInMs);
+                    emitter.CallDeferred("_Process", sleepTimeInMs);
                 if (isPhysicsProcess)
-                    node!.CallDeferred("_PhysicsProcess", sleepTimeInMs);
+                    emitter.CallDeferred("_PhysicsProcess", sleepTimeInMs);
                 if (token.IsCancellationRequested)
                     return false;
             }
-
             return true;
         }
         catch (Exception e)
@@ -158,9 +143,7 @@ internal sealed partial class GodotSignalCollector : Godot.RefCounted, IDisposab
     }
 
     internal int Count(Godot.GodotObject emitter, string signalName, Godot.Variant[] args)
-    {
-        if (IsSignalCollecting(emitter, signalName))
-            return collectedSignals[emitter][signalName].FindAll(signalArgs => signalArgs.VariantEquals(args)).Count;
-        return 0;
-    }
+        => IsSignalCollecting(emitter, signalName)
+            ? collectedSignals[emitter][signalName].FindAll(signalArgs => signalArgs.VariantEquals(args)).Count
+            : 0;
 }


### PR DESCRIPTION
GD-121: Add signal monitor
# Why
The emitted signals needs to be monitored over the test runtime.

# What
Provides a new method for starting signal monitoring.
It should be called up directly after the emitter has been created in order to start monitoring the emitted signals.