### PR TITLE
GD-87: Remove temporary solution of `Godot.SourceGenerators.MustBeVariantAnalyzer` warnings

### DIFF
--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -27,7 +27,7 @@ jobs:
         godot-status: ['stable']
         include:
           - godot-version: '4.3'
-            godot-status: 'dev6'
+            godot-status: 'beta1'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -26,7 +26,7 @@ jobs:
         godot-status: ['stable']
         include:
           - godot-version: '4.3'
-            godot-status: 'dev6'
+            godot-status: 'beta1'
 
 
     name: "CI on Godot 🐧 v${{ matrix.godot-version }}-${{ matrix.godot-status }}"

--- a/example/exampleProject.csproj
+++ b/example/exampleProject.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Godot.NET.Sdk">
   <Import Project="../PackageVersions.props" />
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>11.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -12,8 +12,6 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!--Disable warning/error of invalid/incompatible GodotSharp version, the package GdUnit4.API is build by V4.2.0-->
     <NoWarn>NU1605</NoWarn>
-    <!-- Hide Godot.SourceGenerators.MustBeVariantAnalyzer warnings -->
-    <NoWarn>$(NoWarn);AD0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftSdkVersion)" />

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
     "rollForward": "latestMajor"
   },
   "msbuild-sdks": {
-    "Godot.NET.Sdk": "4.2.2"
+    "Godot.NET.Sdk": "4.3.0-beta.1"
   }
 }

--- a/test/gdUnit4Test.csproj
+++ b/test/gdUnit4Test.csproj
@@ -5,7 +5,7 @@
     <Copyright>© 2024 Mike Schulze</Copyright>
     <Authors>Mike Schulze</Authors>
 
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>
     <NullableReferenceTypes>true</NullableReferenceTypes>
@@ -20,8 +20,6 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!--Disable warning/error of invalid/incompatible GodotSharp version, the package GdUnit4.API is build by V4.2.0-->
     <NoWarn>NU1605</NoWarn>
-    <!-- Hide Godot.SourceGenerators.MustBeVariantAnalyzer warnings -->
-    <NoWarn>$(NoWarn);AD0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/src/core/SceneRunnerInputEventIntegrationTest.cs
+++ b/test/src/core/SceneRunnerInputEventIntegrationTest.cs
@@ -155,16 +155,10 @@ public sealed class SceneRunnerInputEventIntegrationTest
                 .OverrideFailureMessage($"Expect the action '{action}' is pressed")
                 .IsTrue();
         }
-
-        // verify all this actions are still handled as pressed
-        foreach (var action in actionsToSimulate)
-            AssertThat(Input.IsActionPressed(action))
-                .OverrideFailureMessage("Expect the action '{action}' is pressed")
-                .IsTrue();
         // other actions are not pressed
         foreach (var action in new[] { "ui_accept", "ui_select", "ui_cancel" })
             AssertThat(Input.IsActionPressed(action))
-                .OverrideFailureMessage("Expect the action '{action}' is NOT pressed")
+                .OverrideFailureMessage($"Expect the action '{action}' is NOT pressed")
                 .IsFalse();
     }
 
@@ -178,10 +172,7 @@ public sealed class SceneRunnerInputEventIntegrationTest
             AssertThat(InputMap.HasAction(action)).IsTrue();
             sceneRunner.SimulateActionPress(action);
             await ISceneRunner.SyncProcessFrame;
-        }
-        // now do release all actions
-        foreach (var action in actionsToSimulate)
-        {
+
             // precondition
             AssertThat(Input.IsActionPressed(action))
                 .OverrideFailureMessage($"Expect the action '{action}' is pressed")
@@ -236,25 +227,6 @@ public sealed class SceneRunnerInputEventIntegrationTest
             .SimulateKeyPress(Key.A);
         await ISceneRunner.SyncProcessFrame;
 
-        // results in two events, first is the shift key is press
-        var eventKey = new InputEventKey
-        {
-            Keycode = Key.Shift,
-            PhysicalKeycode = Key.Shift,
-            Pressed = true,
-            ShiftPressed = true
-        };
-        //verify(_scene_spy, 1)._input(mouseEvent)
-
-        // second is the combination of current press shift and key A
-        eventKey = new InputEventKey
-        {
-            Keycode = Key.A,
-            PhysicalKeycode = Key.A,
-            Pressed = true,
-            ShiftPressed = true
-        };
-        //verify(_scene_spy, 1)._input(mouseEvent)
         AssertThat(Input.IsKeyPressed(Key.Shift)).IsTrue();
         AssertThat(Input.IsKeyPressed(Key.A)).IsTrue();
     }


### PR DESCRIPTION

# Why
We get an compile warning using Godot less than 4.3.beta1  `Godot.SourceGenerators.MustBeVariantAnalyzer` and had a temporary solution to filter them out `<NoWarn>$(NoWarn);AD0001</NoWarn>`

# What
- Upgrade the dependencies to Godot.NET.Sdk `4.3.beta1` and remove the temporary hack
- Fixed failing input action tests according to the Godot 4.3 event changes