### PR TITLE
GD-124: Auto debugger attach for JetBrains Raider to debug tests

### DIFF
--- a/testadapter/src/execution/ITestExecutor.cs
+++ b/testadapter/src/execution/ITestExecutor.cs
@@ -12,7 +12,7 @@ internal interface ITestExecutor : IDisposable
 
     public const int DEFAULT_SESSION_TIMEOUT = 30000;
 
-    public void Run(IFrameworkHandle frameworkHandle, IRunContext runContext, IEnumerable<TestCase> testCases);
+    public void Run(IFrameworkHandle frameworkHandle, IRunContext runContext, List<TestCase> testCases);
 
-    public void Cancel();
+    public void Cancel(IFrameworkHandle frameworkHandle);
 }


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4Net/issues/124

# What
- add new test runner argument `--attach_debugger`, the test runner checks and do wait until the debugger is attached to the process
- some small cleanups