### PR TITLE
Example: Change TestExecutor to use LaunchProcessWithDebuggerAttached instead of AttachDebuggerIfNeed

### DIFF
--- a/example/exampleProject.csproj
+++ b/example/exampleProject.csproj
@@ -15,7 +15,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftSdkVersion)" />
-    <PackageReference Include="gdUnit4.api" Version="4.2.*" />
-    <PackageReference Include="gdUnit4.test.adapter" Version="1.*" />
+<!--    <PackageReference Include="gdUnit4.api" Version="4.2.5" />-->
+<!--    <PackageReference Include="gdUnit4.test.adapter" Version="1.1.2" />-->
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\api\gdUnit4Api.csproj" />
+    <ProjectReference Include="..\testadapter\gdUnit4TestAdapter.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Unfortunately, this is not completely working.

Debugging works (with Rider 2024.2 EAP3), but there is no technical way to listen the `pProcess` output.
```
            var processId = fh2.LaunchProcessWithDebuggerAttached(processStartInfo.FileName, processStartInfo.WorkingDirectory, processStartInfo.Arguments, null);
            pProcess = Process.GetProcessById(processId);
```

Would it be possible to communicate message differently from Godot to the TestExecutor?