### PR TITLE
GD-46: Added support of DataPoint attributes, which make it possible to define parameterized tests with dynamic test data

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -179,10 +179,10 @@ jobs:
             fi
           }
 
-          validate_section '<Output>' 'Discover tests done, 2 TestSuites and total 11 Tests found.'
-          validate_section '<Output>' 'Start executing tests, 11 TestCases total.'
+          validate_section '<Output>' 'Discover tests done, 2 TestSuites and total 13 Tests found.'
+          validate_section '<Output>' 'Start executing tests, 13 TestCases total.'
           validate_section '<Results>' "<Message>Expecting: 'True' but is 'False'</Message>"
-          validate_section '<Results>' '<StackTrace>   at Examples.ExampleTest.failed() in /home/runner/work/gdUnit4Net/gdUnit4Net/example/test/ExampleTest.cs:line 19'
+          validate_section '<Results>' '<StackTrace>   at Examples.ExampleTest.Failed() in /home/runner/work/gdUnit4Net/gdUnit4Net/example/test/ExampleTest.cs:line 18'
           validate_section '<ResultSummary' '<ResultSummary outcome="Failed">'
-          validate_section '<ResultSummary' '<Counters total="11" executed="11" passed="10" failed="1" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />'
+          validate_section '<ResultSummary' '<Counters total="13" executed="13" passed="12" failed="1" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />'
           echo "All tests passes."

--- a/PackageVersions.props
+++ b/PackageVersions.props
@@ -5,7 +5,7 @@
     <MicrosoftSdkVersion>17.9.0</MicrosoftSdkVersion>
     <MicrosoftCodeAnalysisCSharpVersion>4.9.2</MicrosoftCodeAnalysisCSharpVersion>
     <MoqVersion>4.18.4</MoqVersion>
-    <GdUnitAPIVersion>4.4.0-rc2</GdUnitAPIVersion>
+    <GdUnitAPIVersion>4.4.0-rc3</GdUnitAPIVersion>
     <GdUnitTestAdapterVersion>2.1.0-rc2</GdUnitTestAdapterVersion>
   </PropertyGroup>
 </Project>

--- a/api/ReleaseNotes.txt
+++ b/api/ReleaseNotes.txt
@@ -2,6 +2,7 @@
 v4.4.0-rc*
 
 Improvements:
+* GD-46: Added support of DataPoint attributes, which make it possible to define parameterized tests with dynamic test data
 * GD-138: Added capture test case execution stdout to the test report if `CaptureStdOut` is enabled
 * GD-140: Code cleanup and fix formatting, fix warnings
 * GD-144: Added AwaitInputProcessed to SceneRunner

--- a/api/src/core/attributes/DataPointAttribute.cs
+++ b/api/src/core/attributes/DataPointAttribute.cs
@@ -80,13 +80,13 @@ using System;
 /// </code>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method, Inherited = false)]
-public class DataPointAttribute : TestStageAttribute
+public class DataPointAttribute : Attribute
 {
     /// <summary>
     ///     Initializes a new instance of the DataPointAttribute class with a data source.
     /// </summary>
     /// <param name="dataPointSource">The name of the property or method that provides the test data.</param>
-    public DataPointAttribute(string dataPointSource) : base("", -1)
+    public DataPointAttribute(string dataPointSource)
     {
         DataPointSource = dataPointSource;
         DataPointParameters = null;
@@ -97,7 +97,7 @@ public class DataPointAttribute : TestStageAttribute
     /// </summary>
     /// <param name="dataPointSource">The name of the property or method that provides the test data.</param>
     /// <param name="dataPointDeclaringType">The type that contains the data source.</param>
-    public DataPointAttribute(string dataPointSource, Type dataPointDeclaringType) : base("", -1)
+    public DataPointAttribute(string dataPointSource, Type dataPointDeclaringType)
     {
         DataPointDeclaringType = dataPointDeclaringType;
         DataPointSource = dataPointSource;
@@ -109,7 +109,7 @@ public class DataPointAttribute : TestStageAttribute
     /// </summary>
     /// <param name="dataPointSource">The name of the method that provides the test data.</param>
     /// <param name="arguments">Arguments to pass to the data source method.</param>
-    public DataPointAttribute(string dataPointSource, params object?[] arguments) : base("", -1)
+    public DataPointAttribute(string dataPointSource, params object?[] arguments)
     {
         DataPointSource = dataPointSource;
         DataPointParameters = arguments;

--- a/api/src/core/attributes/DataPointAttribute.cs
+++ b/api/src/core/attributes/DataPointAttribute.cs
@@ -1,0 +1,134 @@
+﻿// ReSharper disable once CheckNamespace
+
+namespace GdUnit4;
+
+using System;
+
+/// <summary>
+///     Provides data-driven test capabilities by specifying a data source for a test method.
+///     This attribute allows tests to be executed multiple times with different input data.
+/// </summary>
+/// <remarks>
+///     The DataPointAttribute can be used to source test data from:
+///     <list type="bullet">
+///         <item>
+///             <term>Static Properties</term>
+///             <description>
+///                 Properties that return IEnumerable{object[]} or IAsyncEnumerable{object[]} for multiple parameters,
+///                 or IEnumerable{T}/IAsyncEnumerable{T} for single parameters.
+///             </description>
+///         </item>
+///         <item>
+///             <term>Static Methods</term>
+///             <description>
+///                 Methods that return test data, including parameterized methods for dynamic data generation
+///                 and async methods for asynchronous data delivery.
+///             </description>
+///         </item>
+///     </list>
+///     Example usages:
+///     <code>
+/// public class TestClass
+/// {
+///     // Property data source
+///     public static IEnumerable{object[]} TestData => new[]
+///     {
+///         new object[] { 1, 2, 3 },
+///         new object[] { 4, 5, 9 }
+///     };
+///
+///     // Method data source
+///     public static IEnumerable{object[]} GetTestData(int factor) => new[]
+///     {
+///         new object[] { 1*factor, 2 },
+///         new object[] { 2*factor, 4 }
+///     };
+///
+///     // Async data source
+///     public static async IAsyncEnumerable{object?[]} AsyncData()
+///     {
+///         await Task.Delay(10);
+///         yield return new object?[] { 1, 2, 3 };
+///         await Task.Delay(10);
+///         yield return new object?[] { 4, 5, 9 };
+///     }
+///
+///     // Test method using property data source
+///     [TestCase]
+///     [DataPoint(nameof(TestData))]
+///     public void Test(int a, int b, int expected)
+///     {
+///         AssertThat(a + b).IsEqual(expected);
+///     }
+///
+///     // Test method using method data source with parameters
+///     [TestCase]
+///     [DataPoint(nameof(GetTestData), 2)]
+///     public void TestWithParameter(int value, int expected)
+///     {
+///         AssertThat(value).IsEqual(expected);
+///     }
+///
+///     // Test method using data source from different class
+///     [TestCase]
+///     [DataPoint(nameof(TestData), typeof(ExternalDataClass))]
+///     public void TestWithExternalData(int a, int b, int expected)
+///     {
+///         AssertThat(a + b).IsEqual(expected);
+///     }
+/// }
+/// </code>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+public class DataPointAttribute : TestStageAttribute
+{
+    /// <summary>
+    ///     Initializes a new instance of the DataPointAttribute class with a data source.
+    /// </summary>
+    /// <param name="dataPointSource">The name of the property or method that provides the test data.</param>
+    public DataPointAttribute(string dataPointSource) : base("", -1)
+    {
+        DataPointSource = dataPointSource;
+        DataPointParameters = null;
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the DataPointAttribute class with a data source from a specified type.
+    /// </summary>
+    /// <param name="dataPointSource">The name of the property or method that provides the test data.</param>
+    /// <param name="dataPointDeclaringType">The type that contains the data source.</param>
+    public DataPointAttribute(string dataPointSource, Type dataPointDeclaringType) : base("", -1)
+    {
+        DataPointDeclaringType = dataPointDeclaringType;
+        DataPointSource = dataPointSource;
+        DataPointParameters = null;
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the DataPointAttribute class with a data source and parameters.
+    /// </summary>
+    /// <param name="dataPointSource">The name of the method that provides the test data.</param>
+    /// <param name="arguments">Arguments to pass to the data source method.</param>
+    public DataPointAttribute(string dataPointSource, params object?[] arguments) : base("", -1)
+    {
+        DataPointSource = dataPointSource;
+        DataPointParameters = arguments;
+    }
+
+    /// <summary>
+    ///     Gets the type that contains the data source method or property.
+    ///     If null, the test class is used.
+    /// </summary>
+    internal Type? DataPointDeclaringType { get; }
+
+    /// <summary>
+    ///     Gets the name of the method or property that provides the test data.
+    /// </summary>
+    internal string DataPointSource { get; }
+
+    /// <summary>
+    ///     Gets the arguments to pass to the data source method.
+    ///     Will be null for properties or methods without parameters.
+    /// </summary>
+    internal object?[]? DataPointParameters { get; }
+}

--- a/api/src/core/attributes/ThrowsExceptionAttribute.cs
+++ b/api/src/core/attributes/ThrowsExceptionAttribute.cs
@@ -1,0 +1,80 @@
+﻿// ReSharper disable once CheckNamespace
+
+namespace GdUnit4;
+
+using System;
+
+using Core.Execution.Exceptions;
+using Core.Extensions;
+
+/// <summary>
+///     Specifies that a test method is expected to throw an exception to the given type.
+///     The test will only pass if the expected exception is thrown and optionally matches
+///     the specified exception message.
+/// </summary>
+/// <remarks>
+///     This attribute can be used to verify that a test method correctly throws
+///     expected exceptions under specific conditions.
+///     Example usage:
+///     <code>
+/// [TestCase]
+/// [ThrowsException(typeof(ArgumentNullException))]
+/// public void TestExpectedNullException()
+/// {
+///     string? value = null;
+///     value.Length; // This will throw ArgumentNullException
+/// }
+///
+/// [TestCase]
+/// [ThrowsException(typeof(ArgumentException), "Invalid argument")]
+/// public void TestExpectedExceptionWithMessage()
+/// {
+///     throw new ArgumentException("Invalid argument");
+/// }
+/// </code>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+internal class ThrowsExceptionAttribute : Attribute
+{
+    private readonly Type expectedExceptionType;
+    private readonly string? expectedMessage;
+
+    /// <summary>
+    ///     Initializes a new instance of the ThrowsExceptionAttribute with the specified exception type.
+    /// </summary>
+    /// <param name="expectedExceptionType">The Type of exception that is expected to be thrown</param>
+    internal ThrowsExceptionAttribute(Type expectedExceptionType) => this.expectedExceptionType = expectedExceptionType;
+
+    /// <summary>
+    ///     Initializes a new instance of the ThrowsExceptionAttribute with the specified exception type
+    ///     and expected exception message.
+    /// </summary>
+    /// <param name="expectedExceptionType">The Type of exception that is expected to be thrown</param>
+    /// <param name="expectedMessage">The expected message of the thrown exception</param>
+    internal ThrowsExceptionAttribute(Type expectedExceptionType, string expectedMessage)
+    {
+        this.expectedExceptionType = expectedExceptionType;
+        this.expectedMessage = expectedMessage;
+    }
+
+    /// <summary>
+    ///     Verifies that the thrown exception matches the expected type and message (if specified).
+    /// </summary>
+    /// <param name="exception">The exception that was thrown during test execution</param>
+    /// <returns>true if the verification passes</returns>
+    /// <exception cref="TestFailedException">
+    ///     Thrown when:
+    ///     - The exception type does not match the expected type
+    ///     - The exception message does not match the expected message (if a message was specified)
+    /// </exception>
+    public bool Verify(Exception exception)
+    {
+        if (exception.GetType() != expectedExceptionType)
+            throw new TestFailedException($"Expecting exception type\n\t{expectedExceptionType}\n but is\n\t{exception.GetType()}.");
+        var exceptionMessage = exception.Message.RichTextNormalize();
+        if (expectedMessage != null && exceptionMessage != expectedMessage)
+            throw new TestFailedException($"Expecting exception message\n\t\"{expectedMessage}\"\n but is\n\t\"{exceptionMessage}\"");
+
+        return true;
+    }
+}

--- a/api/src/core/data/AsyncDataPointCanceledException.cs
+++ b/api/src/core/data/AsyncDataPointCanceledException.cs
@@ -2,10 +2,9 @@
 
 using System;
 
-internal sealed class AsyncDataPointCanceledException : OperationCanceledException
+internal sealed class AsyncDataPointCanceledException : Exception
 {
-    public AsyncDataPointCanceledException(OperationCanceledException baseException, string stackTrace) : base(baseException.Message, baseException.CancellationToken)
-        => StackTrace = stackTrace;
+    public AsyncDataPointCanceledException(string message, string stackTrace) : base(message) => StackTrace = stackTrace;
 
     public override string StackTrace { get; }
 }

--- a/api/src/core/data/AsyncDataPointCanceledException.cs
+++ b/api/src/core/data/AsyncDataPointCanceledException.cs
@@ -1,0 +1,11 @@
+﻿namespace GdUnit4.Core.Data;
+
+using System;
+
+internal sealed class AsyncDataPointCanceledException : OperationCanceledException
+{
+    public AsyncDataPointCanceledException(OperationCanceledException baseException, string stackTrace) : base(baseException.Message, baseException.CancellationToken)
+        => StackTrace = stackTrace;
+
+    public override string StackTrace { get; }
+}

--- a/api/src/core/data/DataPointValueProvider.cs
+++ b/api/src/core/data/DataPointValueProvider.cs
@@ -1,0 +1,403 @@
+﻿// MIT License
+//
+// GdUnit4 - C# Unit testing library for Godot Engine
+//
+// Copyright (c) 2024 Mike Schulze
+// Copyright (c) 2024 GdUnit4 contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace GdUnit4.Core.Data;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Execution;
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+/// <summary>
+///     Provides functionality to retrieve and process test data from data point sources for data-driven tests.
+///     This class handles both synchronous and asynchronous data sources, supporting various data formats
+///     including arrays, enumerables, and single values.
+/// </summary>
+/// <remarks>
+///     The DataPointValueProvider supports the following data source patterns:
+///     <list type="bullet">
+///         <item>
+///             <term>Sync Data Sources</term>
+///             <description>
+///                 - Static properties or methods returning IEnumerable{object?[]}
+///                 - Static properties or methods returning IEnumerable{T} where T is converted to object?[]
+///                 - Parameterized methods for dynamic data generation
+///             </description>
+///         </item>
+///         <item>
+///             <term>Async Data Sources</term>
+///             <description>
+///                 - IAsyncEnumerable{object?[]} for direct array data
+///                 - IAsyncEnumerable{T} where T is wrapped in a single-element array
+///             </description>
+///         </item>
+///     </list>
+///     Example usages:
+///     <code>
+/// // Synchronous array data
+/// public static IEnumerable{object[]} TestData => new[]
+/// {
+///     new object[] { 1, 2, 3 },
+///     new object[] { 4, 5, 9 }
+/// };
+///
+/// // Asynchronous array data
+/// public static async IAsyncEnumerable{object?[]} AsyncData()
+/// {
+///     yield return new object?[] { 1, 2, 3 };
+///     await Task.Delay(10);
+///     yield return new object?[] { 4, 5, 9 };
+/// }
+///
+/// // Single value async data
+/// public static async IAsyncEnumerable{int} AsyncInts()
+/// {
+///     yield return 1;
+///     await Task.Delay(10);
+///     yield return 2;
+/// }
+/// </code>
+/// </remarks>
+internal static class DataPointValueProvider
+{
+    internal static IEnumerable<object?[]> GetData(TestCase testCase)
+    {
+        var dataPoint = testCase.DataPoint ??
+                        throw new ArgumentNullException($"No data point specified at {testCase.DataPoint}.");
+        var declaringType = dataPoint.DataPointDeclaringType ?? testCase.MethodInfo.DeclaringType ??
+            throw new ArgumentNullException($"No declaring type found for {dataPoint.DataPointDeclaringType}");
+
+
+        // get data from property
+        var dataSource = GetDataPointSource(declaringType, dataPoint, out _);
+
+        if (dataSource == null)
+            throw new ArgumentNullException($"Value returned by property or method {dataPoint.DataPointSource} shouldn't be null.");
+
+        if (!TryGetData(dataSource, out var data))
+            throw new ArgumentException(
+                $"Data source '{dataPoint.DataPointSource}' in {declaringType.FullName} must return IEnumerable<object?[]> or IEnumerable<object?>");
+
+        return data;
+    }
+
+    internal static async IAsyncEnumerable<object?[]> GetDataAsync(TestCase testCase, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var dataPoint = testCase.DataPoint ??
+                        throw new ArgumentNullException($"No data point specified at {testCase.DataPoint}.");
+
+        var declaringType = dataPoint.DataPointDeclaringType ?? testCase.MethodInfo.DeclaringType ??
+            throw new ArgumentNullException($"No declaring type found for {dataPoint.DataPointDeclaringType}");
+
+        var dataSource = GetDataPointSource(declaringType, dataPoint, out var returnType);
+
+        if (dataSource == null)
+            throw new ArgumentNullException($"Value returned by async property or method {dataPoint.DataPointSource} shouldn't be null.");
+
+        if (!IsAsyncEnumerableType(returnType!))
+            throw new ArgumentException($"Data source '{dataPoint.DataPointSource}' in {declaringType.FullName} must return IAsyncEnumerable<T>");
+
+        await foreach (var item in StreamAsyncData(dataSource, returnType!, cancellationToken)) yield return item;
+    }
+
+    private static async IAsyncEnumerable<object?[]> StreamAsyncData(object asyncSource, Type returnType, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var elementType = returnType.GetGenericArguments()[0];
+
+        // Handle IAsyncEnumerable<object?[]>
+        if (elementType == typeof(object[]) || elementType == typeof(object?[]))
+        {
+            // Direct cast for object arrays
+            var enumerable = (IAsyncEnumerable<object?[]>)asyncSource;
+            var enumerator = enumerable.GetAsyncEnumerator(cancellationToken);
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    try
+                    {
+                        // We use Task.WaitAsync to enforce timeout
+                        var hasNext = await enumerator.MoveNextAsync()
+                            .AsTask()
+                            .WaitAsync(cancellationToken)
+                            .ConfigureAwait(false);
+
+                        if (!hasNext)
+                            break;
+                    }
+                    catch (OperationCanceledException e)
+                    {
+                        var stacktrace = BuildStackTrace(asyncSource);
+                        throw new AsyncDataPointCanceledException(e, stacktrace);
+                    }
+
+                    yield return enumerator.Current;
+                }
+            }
+            finally
+            {
+                try
+                {
+                    if (enumerator is IAsyncDisposable disposable) await disposable.DisposeAsync();
+                }
+                catch (Exception e) when (e is NotImplementedException or NotSupportedException)
+                {
+                    // ignore it
+                }
+            }
+        }
+        // Handle IAsyncEnumerable<T> for simple types
+        else
+        {
+            var enumerableInterface = typeof(IAsyncEnumerable<>).MakeGenericType(elementType);
+            var enumeratorInterface = typeof(IAsyncEnumerator<>).MakeGenericType(elementType);
+
+            // Get the GetAsyncEnumerator method from the interface
+            var getEnumeratorMethod = enumerableInterface.GetMethod("GetAsyncEnumerator");
+            if (getEnumeratorMethod == null)
+                throw new InvalidOperationException($"Could not find GetAsyncEnumerator method on {enumerableInterface.FullName}");
+
+            var enumerator = getEnumeratorMethod.Invoke(asyncSource, new object[] { cancellationToken });
+            if (enumerator == null)
+                throw new InvalidOperationException("GetAsyncEnumerator returned null");
+
+            var moveNextMethod = enumeratorInterface.GetMethod("MoveNextAsync");
+            var currentProperty = enumeratorInterface.GetProperty("Current");
+
+            if (moveNextMethod == null || currentProperty == null)
+                throw new InvalidOperationException("Could not find required members on enumerator interface");
+
+            try
+            {
+                while (await (ValueTask<bool>)moveNextMethod.Invoke(enumerator, null)!)
+                {
+                    var current = currentProperty.GetValue(enumerator);
+                    yield return new[] { current };
+                }
+            }
+            finally
+            {
+                if (enumerator is IAsyncDisposable disposable) await disposable.DisposeAsync();
+            }
+        }
+    }
+
+    private static string? LookupClassPath(Type classType) => new DirectoryInfo(Directory.GetCurrentDirectory())
+        .EnumerateFiles($"*{classType.Name}.cs", SearchOption.AllDirectories)
+        .Where(file => FileContainsClassName(file.FullName, classType.Name))
+        .Select(file => file.FullName)
+        .FirstOrDefault();
+
+    // Check if the class name exists in the file using a quick text check
+    private static bool FileContainsClassName(string filePath, string className)
+    {
+        // Read file line-by-line instead of loading the whole file into memory
+        using var reader = new StreamReader(filePath);
+        while (reader.ReadLine() is { } line)
+            // If the line contains the class keyword and the class name, it's a likely candidate
+            if (line.Contains($"class {className}"))
+                return true;
+
+        return false;
+    }
+
+    private static string BuildStackTrace(object asyncSource)
+    {
+        try
+        {
+            var sourceType = asyncSource.GetType();
+            if (!sourceType.Name.Contains("d__"))
+                return "at unknown location";
+
+            var originalType = sourceType.DeclaringType;
+
+            if (originalType == null)
+                return "at unknown location";
+
+            var methodName = sourceType.Name.Split('<', '>')[1];
+            var sourceFile = LookupClassPath(originalType);
+            if (sourceFile == null) return $"at {originalType.FullName}.{methodName}";
+
+            // If we found the source file, parse it to find the method line
+            var sourceText = File.ReadAllText(sourceFile);
+            var tree = CSharpSyntaxTree.ParseText(sourceText);
+            var root = tree.GetRoot();
+
+            var methodDeclaration = root
+                .DescendantNodes()
+                .OfType<MethodDeclarationSyntax>()
+                .FirstOrDefault(m => m.Identifier.ValueText == methodName);
+
+            if (methodDeclaration != null)
+            {
+                var lineSpan = tree.GetLineSpan(methodDeclaration.Span);
+                var lineNumber = lineSpan.StartLinePosition.Line + 1;
+                return $"at {originalType.FullName}.{methodName} in {sourceFile}:line {lineNumber}";
+            }
+
+            // For now, return basic information while we examine the debug output
+            return $"at {originalType.FullName}.{methodName}";
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"Error getting source location: {e}");
+            return "at unknown location";
+        }
+    }
+
+    private static object? GetDataPointSource(Type declaringType, DataPointAttribute dataPoint, out Type? returnType)
+    {
+        // First try to get as property
+        var property = declaringType.GetProperty(dataPoint.DataPointSource,
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+
+        if (property != null)
+        {
+            if (!property.CanRead)
+                throw new ArgumentException(
+                    $"Property '{dataPoint.DataPointSource}' in {declaringType.FullName} must have a getter");
+            returnType = property.PropertyType;
+
+            return property.GetValue(null, null);
+        }
+
+        // Then try as method
+        var method = declaringType.GetMethod(dataPoint.DataPointSource,
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+
+        if (method == null)
+            throw new ArgumentException(
+                $"No property or method named '{dataPoint.DataPointSource}' found in {declaringType.FullName}");
+
+        if (dataPoint.DataPointParameters != null) ValidateMethodParameters(method, dataPoint.DataPointParameters);
+
+        returnType = method.ReturnType;
+        return method.Invoke(null, dataPoint.DataPointParameters);
+    }
+
+    private static void ValidateMethodParameters(MethodInfo method, object?[] providedParameters)
+    {
+        var methodParameters = method.GetParameters();
+
+        if (methodParameters.Length != providedParameters.Length)
+            throw new ArgumentException($"Method '{method.Name}' expects {methodParameters.Length} parameters but {providedParameters.Length} were provided");
+
+        for (var i = 0; i < methodParameters.Length; i++)
+        {
+            var parameterType = methodParameters[i].ParameterType;
+            var providedValue = providedParameters[i];
+
+            if (providedValue != null && !parameterType.IsInstanceOfType(providedValue))
+                throw new ArgumentException($"Parameter {i} of method '{method.Name}' expects type {parameterType.Name} but got {providedValue.GetType().Name}");
+        }
+    }
+
+    internal static bool IsAsyncDataPoint(TestCase testCase)
+    {
+        var dataPoint = testCase.DataPoint;
+        if (dataPoint == null) return false;
+
+        var declaringType = dataPoint.DataPointDeclaringType ?? testCase.MethodInfo.DeclaringType;
+        if (declaringType == null) return false;
+
+        // Check property
+        var property = declaringType.GetProperty(dataPoint.DataPointSource,
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+
+        if (property != null)
+        {
+            var propertyType = property.PropertyType;
+            return IsAsyncEnumerableType(propertyType);
+        }
+
+        // Check method
+        var method = declaringType.GetMethod(dataPoint.DataPointSource,
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+
+        if (method != null)
+        {
+            var returnType = method.ReturnType;
+            return IsAsyncEnumerableType(returnType);
+        }
+
+        return false;
+    }
+
+    private static bool IsAsyncEnumerableType(Type type)
+    {
+        if (!type.IsGenericType)
+            return false;
+        return type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>);
+    }
+
+    private static bool TryGetData(object? dataSource, [NotNullWhen(true)] out IEnumerable<object?[]>? data)
+    {
+        data = null;
+
+        if (dataSource == null) return false;
+
+        // Handle IEnumerable<object?[]> directly
+        if (dataSource is IEnumerable<object?[]> arrayData)
+        {
+            data = arrayData;
+            return true;
+        }
+
+        // Handle IEnumerable<object?> by converting single objects to arrays
+        if (dataSource is IEnumerable<object?> singleData)
+        {
+            data = singleData.Select(item => new[] { item });
+            return true;
+        }
+
+        // Handle general IEnumerable
+        if (dataSource is IEnumerable enumerable)
+        {
+            var resultList = new List<object?[]>();
+
+            foreach (var item in enumerable)
+                if (item is object?[] array)
+                    resultList.Add(array);
+                else resultList.Add(new[] { item });
+
+            if (resultList.Count == 0) return false;
+            data = resultList;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/api/src/core/execution/ExecutionContext.cs
+++ b/api/src/core/execution/ExecutionContext.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 
 using Events;
@@ -72,7 +73,7 @@ internal sealed class ExecutionContext : IDisposable
         IsSkipped = CurrentTestCase?.IsSkipped ?? false;
     }
 
-    public TimeSpan ExecutionTimeout { get; set; } = TimeSpan.FromSeconds(30);
+    private TimeSpan ExecutionTimeout { get; } = TimeSpan.FromSeconds(30);
 
     public bool IsCaptureStdOut
     {
@@ -189,6 +190,15 @@ internal sealed class ExecutionContext : IDisposable
             catch (ObjectDisposedException e) { _ = e; }
         });
         Stopwatch.Stop();
+    }
+
+    public bool IsExpectingFailByException(Exception exception)
+    {
+        var expectFailByExceptionAttribute = CurrentTestCase?.MethodInfo.GetCustomAttribute<ThrowsExceptionAttribute>();
+        if (expectFailByExceptionAttribute == null)
+            return false;
+
+        return expectFailByExceptionAttribute.Verify(exception);
     }
 
     private int OrphanCount(bool recursive)

--- a/api/src/core/execution/ExecutionContext.cs
+++ b/api/src/core/execution/ExecutionContext.cs
@@ -192,13 +192,13 @@ internal sealed class ExecutionContext : IDisposable
         Stopwatch.Stop();
     }
 
-    public bool IsExpectingFailByException(Exception exception)
+    public bool IsExpectingToFailWithException(Exception exception)
     {
-        var expectFailByExceptionAttribute = CurrentTestCase?.MethodInfo.GetCustomAttribute<ThrowsExceptionAttribute>();
-        if (expectFailByExceptionAttribute == null)
+        var attribute = CurrentTestCase?.MethodInfo.GetCustomAttribute<ThrowsExceptionAttribute>();
+        if (attribute == null)
             return false;
 
-        return expectFailByExceptionAttribute.Verify(exception);
+        return attribute.Verify(exception);
     }
 
     private int OrphanCount(bool recursive)

--- a/api/src/core/execution/ExecutionContext.cs
+++ b/api/src/core/execution/ExecutionContext.cs
@@ -72,6 +72,8 @@ internal sealed class ExecutionContext : IDisposable
         IsSkipped = CurrentTestCase?.IsSkipped ?? false;
     }
 
+    public TimeSpan ExecutionTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
     public bool IsCaptureStdOut
     {
         get;
@@ -234,4 +236,7 @@ internal sealed class ExecutionContext : IDisposable
 
     public void PrintDebug(string name = "")
         => GD.PrintS(name, "test context", TestSuite.Name, TestCaseName, "error:" + IsError, "failed:" + IsFailed, "skipped:" + IsSkipped);
+
+    public TimeSpan GetExecutionTimeout(TestCaseAttribute testAttribute) =>
+        testAttribute.Timeout == -1 ? ExecutionTimeout : TimeSpan.FromMilliseconds(testAttribute.Timeout);
 }

--- a/api/src/core/execution/ExecutionStage.cs
+++ b/api/src/core/execution/ExecutionStage.cs
@@ -67,6 +67,8 @@ internal abstract class ExecutionStage<T> : IExecutionStage
         }
         catch (ExecutionTimeoutException e)
         {
+            if (context.IsExpectingFailByException(e))
+                return;
             if (context.FailureReporting)
                 context.ReportCollector.Consume(new TestReport(ReportType.INTERRUPTED, e.LineNumber, e.Message));
         }
@@ -95,6 +97,8 @@ internal abstract class ExecutionStage<T> : IExecutionStage
 
     private static void ReportAsFailure(ExecutionContext context, TestFailedException e)
     {
+        if (context.IsExpectingFailByException(e))
+            return;
         if (context.FailureReporting)
             context.ReportCollector.Consume(new TestReport(e));
     }
@@ -104,6 +108,8 @@ internal abstract class ExecutionStage<T> : IExecutionStage
         if (exception is TargetInvocationException)
         {
             var ei = ExceptionDispatchInfo.Capture(exception.InnerException ?? exception);
+            if (context.IsExpectingFailByException(ei.SourceException))
+                return;
             ReportUnexpectedException(context, ei.SourceException);
         }
         else

--- a/api/src/core/execution/ExecutionStage.cs
+++ b/api/src/core/execution/ExecutionStage.cs
@@ -67,7 +67,7 @@ internal abstract class ExecutionStage<T> : IExecutionStage
         }
         catch (ExecutionTimeoutException e)
         {
-            if (context.IsExpectingFailByException(e))
+            if (context.IsExpectingToFailWithException(e))
                 return;
             if (context.FailureReporting)
                 context.ReportCollector.Consume(new TestReport(ReportType.INTERRUPTED, e.LineNumber, e.Message));
@@ -97,7 +97,7 @@ internal abstract class ExecutionStage<T> : IExecutionStage
 
     private static void ReportAsFailure(ExecutionContext context, TestFailedException e)
     {
-        if (context.IsExpectingFailByException(e))
+        if (context.IsExpectingToFailWithException(e))
             return;
         if (context.FailureReporting)
             context.ReportCollector.Consume(new TestReport(e));
@@ -108,7 +108,7 @@ internal abstract class ExecutionStage<T> : IExecutionStage
         if (exception is TargetInvocationException)
         {
             var ei = ExceptionDispatchInfo.Capture(exception.InnerException ?? exception);
-            if (context.IsExpectingFailByException(ei.SourceException))
+            if (context.IsExpectingToFailWithException(ei.SourceException))
                 return;
             ReportUnexpectedException(context, ei.SourceException);
         }

--- a/api/src/core/execution/TestCase.cs
+++ b/api/src/core/execution/TestCase.cs
@@ -33,6 +33,10 @@ internal sealed class TestCase
 
     internal bool IsParameterized => TestCaseAttributes.Any(p => p.Arguments.Length > 0);
 
+    internal bool HasDataPoint => DataPoint != null;
+
+    internal DataPointAttribute? DataPoint => MethodInfo.GetCustomAttribute<DataPointAttribute>();
+
     public bool IsSkipped => Attribute.IsDefined(MethodInfo, typeof(IgnoreUntilAttribute));
 
     private IEnumerable<object> Parameters

--- a/api/src/core/execution/TestSuiteExecutionStage.cs
+++ b/api/src/core/execution/TestSuiteExecutionStage.cs
@@ -83,7 +83,7 @@ internal sealed class TestSuiteExecutionStage : IExecutionStage
                 }
                 catch (AsyncDataPointCanceledException e)
                 {
-                    if (!executionContext.IsExpectingFailByException(e))
+                    if (!executionContext.IsExpectingToFailWithException(e))
                         executionContext.ReportCollector.Consume(
                             new TestReport(
                                 TestReport.ReportType.INTERRUPTED,

--- a/api/src/core/execution/TestSuiteExecutionStage.cs
+++ b/api/src/core/execution/TestSuiteExecutionStage.cs
@@ -2,12 +2,9 @@ namespace GdUnit4.Core.Execution;
 
 using System;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 using Data;
-
-using Extensions;
 
 using Hooks;
 
@@ -75,14 +72,10 @@ internal sealed class TestSuiteExecutionStage : IExecutionStage
         {
             var testAttribute = testCase.TestCaseAttributes.First();
             if (DataPointValueProvider.IsAsyncDataPoint(testCase))
-            {
-                // Create a cancellation token that will timeout after the specified duration
-                var timeout = executionContext.GetExecutionTimeout(testAttribute);
-                using var cts = new CancellationTokenSource(timeout);
-
                 try
                 {
-                    await foreach (var dataPointValues in DataPointValueProvider.GetDataAsync(testCase, cts.Token).ConfigureAwait(false))
+                    var timeout = executionContext.GetExecutionTimeout(testAttribute);
+                    await foreach (var dataPointValues in DataPointValueProvider.GetDataAsync(testCase, timeout).ConfigureAwait(false))
                     {
                         using ExecutionContext testCaseContext = new(executionContext, testCase, testCase.TestCaseAttributes);
                         await RunTestCase(stdoutHook, testCaseContext, testCase, testAttribute, dataPointValues);
@@ -90,25 +83,21 @@ internal sealed class TestSuiteExecutionStage : IExecutionStage
                 }
                 catch (AsyncDataPointCanceledException e)
                 {
-                    executionContext.ReportCollector.Consume(
-                        new TestReport(
-                            TestReport.ReportType.INTERRUPTED,
-                            executionContext.CurrentTestCase?.Line ?? -1,
-                            $"The execution has timed out after {timeout.Humanize()}.",
-                            e.StackTrace));
+                    if (!executionContext.IsExpectingFailByException(e))
+                        executionContext.ReportCollector.Consume(
+                            new TestReport(
+                                TestReport.ReportType.INTERRUPTED,
+                                executionContext.CurrentTestCase?.Line ?? -1,
+                                e.Message,
+                                e.StackTrace));
                 }
-            }
             else
-            {
-                var dataPoints = DataPointValueProvider.GetData(testCase);
-                foreach (var dataPointValues in dataPoints)
+                foreach (var dataPointValues in DataPointValueProvider.GetData(testCase))
                 {
                     using ExecutionContext testCaseContext = new(executionContext, testCase, testCase.TestCaseAttributes);
                     await RunTestCase(stdoutHook, testCaseContext, testCase, testAttribute, dataPointValues);
                 }
-            }
         }
-
         catch (Exception e)
         {
             executionContext.ReportCollector.Consume(new TestReport(TestReport.ReportType.FAILURE, executionContext.CurrentTestCase?.Line ?? -1, e.Message, e.StackTrace));
@@ -132,24 +121,30 @@ internal sealed class TestSuiteExecutionStage : IExecutionStage
     private async Task RunTestCase(IStdOutHook? stdoutHook, ExecutionContext executionContext, TestCase testCase, TestCaseAttribute stageAttribute,
         params object?[] methodArguments)
     {
-        // start capturing stdout if enabled
-        stdoutHook?.StartCapture();
-
-        await BeforeTestStage.Execute(executionContext);
-        using (ExecutionContext context = new(executionContext, methodArguments))
-            await new TestCaseExecutionStage(context.TestCaseName, testCase, stageAttribute).Execute(context);
-
-        // stop capturing stdout and add as report if enabled
-        stdoutHook?.StopCapture();
-        var stdoutMessage = stdoutHook?.GetCapturedOutput();
-        if (!string.IsNullOrEmpty(stdoutMessage))
+        try
         {
-            executionContext.ReportCollector.PushFront(new TestReport(TestReport.ReportType.STDOUT,
-                executionContext.CurrentTestCase?.Line ?? 0, stdoutMessage));
-            // and finally redirect to the console because it was fully captured
-            Console.WriteLine(stdoutMessage);
-        }
+            // start capturing stdout if enabled
+            stdoutHook?.StartCapture();
 
-        await AfterTestStage.Execute(executionContext);
+            await BeforeTestStage.Execute(executionContext);
+
+            using ExecutionContext context = new(executionContext, methodArguments);
+            await new TestCaseExecutionStage(context.TestCaseName, testCase, stageAttribute).Execute(context);
+        }
+        finally
+        {
+            // stop capturing stdout and add as report if enabled
+            stdoutHook?.StopCapture();
+            var stdoutMessage = stdoutHook?.GetCapturedOutput();
+            if (!string.IsNullOrEmpty(stdoutMessage))
+            {
+                executionContext.ReportCollector.PushFront(new TestReport(TestReport.ReportType.STDOUT,
+                    executionContext.CurrentTestCase?.Line ?? 0, stdoutMessage));
+                // and finally redirect to the console because it was fully captured
+                Console.WriteLine(stdoutMessage);
+            }
+
+            await AfterTestStage.Execute(executionContext);
+        }
     }
 }

--- a/example/exampleProject.csproj
+++ b/example/exampleProject.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftSdkVersion)"/>
-    <PackageReference Include="gdUnit4.api" Version="4.4.0-rc2"/>
+    <PackageReference Include="gdUnit4.api" Version="4.4.0-rc3"/>
     <PackageReference Include="gdUnit4.test.adapter" Version="2.1.0-rc2"/>
   </ItemGroup>
 </Project>

--- a/example/test/ExampleTest.cs
+++ b/example/test/ExampleTest.cs
@@ -1,22 +1,27 @@
 namespace Examples;
 
 using GdUnit4;
+
 using static GdUnit4.Assertions;
 
 [TestSuite]
 public class ExampleTest
 {
-    [TestCase]
-    public void success()
-    {
-        AssertBool(true).IsTrue();
-    }
-
+    public static IEnumerable<object[]> ArrayDataPointProperty => new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 9 } };
+    public static IEnumerable<object[]> ArrayDataPointMethod() => new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 9 } };
 
     [TestCase]
-    public void failed()
-    {
-        AssertBool(false).IsTrue();
-    }
+    public void Success() => AssertBool(true).IsTrue();
 
+
+    [TestCase]
+    public void Failed() => AssertBool(false).IsTrue();
+
+    [TestCase]
+    [DataPoint(nameof(ArrayDataPointProperty))]
+    public void WithDataPointProperty(int a, int b, int expected) => AssertThat(a + b).IsEqual(expected);
+
+    [TestCase]
+    [DataPoint(nameof(ArrayDataPointMethod))]
+    public void WithArrayDataPointMethod(int a, int b, int expected) => AssertThat(a + b).IsEqual(expected);
 }

--- a/test/src/core/ExternalDataPoints.cs
+++ b/test/src/core/ExternalDataPoints.cs
@@ -1,0 +1,14 @@
+﻿namespace GdUnit4.Tests.Core;
+
+using System.Collections.Generic;
+
+public static class ExternalDataPoints
+{
+    public static IEnumerable<object[]> PublicArrayDataPointProperty => new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 9 } };
+    private static IEnumerable<object[]> PrivateArrayDataPointProperty => new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 9 } };
+
+    public static IEnumerable<object[]> PublicArrayDataPointMethod() => new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 9 } };
+#pragma warning disable CA1859 // #warning directive
+    private static IEnumerable<object[]> PrivateArrayDataPointMethod() => new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 9 } };
+#pragma warning restore CA1859 // #warning directive
+}

--- a/test/src/core/TestSuiteWithDynamicDataPoints.cs
+++ b/test/src/core/TestSuiteWithDynamicDataPoints.cs
@@ -3,6 +3,8 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
+using GdUnit4.Core.Data;
+
 using static Assertions;
 
 /// <summary>
@@ -120,9 +122,9 @@ public class TestSuiteWithDynamicDataPoints
     [DataPoint(nameof(AsyncSingleDataPoint))]
     public void OnAsyncSingleDataPoint(int a) => AssertThat(a).IsBetween(1, 3);
 
-
     [TestCase(Timeout = 100)]
     [DataPoint(nameof(AsyncArrayDataPointBlocked))]
+    [ThrowsException(typeof(AsyncDataPointCanceledException), "The execution has timed out after 100ms.")]
     public void OnAsyncArrayDataPointFailByTimeout(int a, int b, int expected) => AssertThat(a + b).IsEqual(expected);
 
     #endregion

--- a/test/src/core/TestSuiteWithDynamicDataPoints.cs
+++ b/test/src/core/TestSuiteWithDynamicDataPoints.cs
@@ -1,0 +1,129 @@
+﻿namespace GdUnit4.Tests.Core;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using static Assertions;
+
+/// <summary>
+///     The test are similar to https://github.com/microsoft/testfx/blob/cdc374674477f23502f58b5be503ed609ba4057c/docs/RFCs/006-DynamicData-Attribute.md
+/// </summary>
+[TestSuite]
+public class TestSuiteWithDynamicDataPoints
+{
+    public static IEnumerable<object[]> ArrayDataPointProperty => new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 9 } };
+    public static IEnumerable<int> SingleDataPointProperty => new[] { 1, 2, 3 };
+    public static IEnumerable<object[]> ArrayDataPointMethod() => new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 9 } };
+    public static IEnumerable<object[]> PublicTestDataFactory(int factor) => new[] { new object[] { 1 * factor, 1 * factor }, new object[] { 2 * factor, 2 * factor } };
+
+#pragma warning disable CA1859 // #warning directive
+    private static IEnumerable<object[]> PrivateArrayDataPointProperty => new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 9 } };
+    private static IEnumerable<object[]> PrivateArrayDataPointMethod() => new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 9 } };
+    private static IEnumerable<object[]> PrivateTestDataFactory(int factor) => new[] { new object[] { 1 * factor, 1 * factor }, new object[] { 2 * factor, 2 * factor } };
+#pragma warning restore CS1030 // #warning directive
+
+
+    internal static IEnumerable<object[]> YieldedDataPointMethod()
+    {
+        yield return new object[] { 1, 2, 3 };
+        yield return new object[] { 4, 5, 9 };
+    }
+
+    #region private_data_points
+
+    [TestCase]
+    [DataPoint(nameof(PrivateArrayDataPointProperty))]
+    public void OnPrivateArrayDataPointProperty(int a, int b, int expected) => AssertThat(a + b).IsEqual(expected);
+
+    [TestCase]
+    [DataPoint(nameof(PrivateArrayDataPointMethod))]
+    public void OnPrivateArrayDataPointMethod(int a, int b, int expected) => AssertThat(a + b).IsEqual(expected);
+
+    [TestCase]
+    [DataPoint("PrivateArrayDataPointProperty", typeof(ExternalDataPoints))]
+    public void OnExternalPrivateArrayDataPointProperty(int a, int b, int expected) => AssertThat(a + b).IsEqual(expected);
+
+    [TestCase]
+    [DataPoint("PrivateArrayDataPointMethod", typeof(ExternalDataPoints))]
+    public void OnExternalPrivateArrayDataPointMethod(int a, int b, int expected) => AssertThat(a + b).IsEqual(expected);
+
+    [TestCase]
+    [DataPoint(nameof(PrivateTestDataFactory), 2)]
+    public void ParameterizedPrivateDataPoint(int value, int expected) => AssertThat(value).IsEqual(expected);
+
+    #endregion
+
+    #region public_data_points
+
+    [TestCase]
+    [DataPoint(nameof(ArrayDataPointProperty))]
+    public void OnPublicArrayDataPointProperty(int a, int b, int expected) => AssertThat(a + b).IsEqual(expected);
+
+    [TestCase]
+    [DataPoint(nameof(SingleDataPointProperty))]
+    public void OnPublicSingleDataPointProperty(int value) => AssertThat(value).IsBetween(1, 3);
+
+    [TestCase]
+    [DataPoint(nameof(ArrayDataPointMethod))]
+    public void OnPublicArrayDataPointMethod(int a, int b, int expected) => AssertThat(a + b).IsEqual(expected);
+
+    [TestCase]
+    [DataPoint(nameof(YieldedDataPointMethod))]
+    public void DataPointYieldedMethod(int a, int b, int expected) => AssertThat(a + b).IsEqual(expected);
+
+    [TestCase]
+    [DataPoint(nameof(ExternalDataPoints.PublicArrayDataPointProperty), typeof(ExternalDataPoints))]
+    public void OnExternalPublicArrayDataPointProperty(int a, int b, int expected) => AssertThat(a + b).IsEqual(expected);
+
+    [TestCase]
+    [DataPoint(nameof(ExternalDataPoints.PublicArrayDataPointMethod), typeof(ExternalDataPoints))]
+    public void OnExternalPublicArrayDataPointMethod(int a, int b, int expected) => AssertThat(a + b).IsEqual(expected);
+
+    [TestCase]
+    [DataPoint(nameof(PublicTestDataFactory), 2)]
+    public void ParameterizedPublicDataPoint(int value, int expected) => AssertThat(value).IsEqual(expected);
+
+    #endregion
+
+    #region public_async_data_points
+
+    public static async IAsyncEnumerable<object?[]> AsyncArrayDataPoint()
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            // Simulate async work for each item
+            await Task.Delay(10);
+            yield return new object?[] { i, i + 1, i + i + 1 };
+        }
+    }
+
+    public static async IAsyncEnumerable<object?[]> AsyncArrayDataPointBlocked()
+    {
+        await Task.Delay(500);
+        yield return new object?[] { 1, 2, 3 };
+    }
+
+    public static async IAsyncEnumerable<int> AsyncSingleDataPoint()
+    {
+        yield return 1;
+        await Task.Delay(10);
+        yield return 2;
+        await Task.Delay(10);
+        yield return 3;
+    }
+
+    [TestCase]
+    [DataPoint(nameof(AsyncArrayDataPoint))]
+    public void OnAsyncArrayDataPoint(int a, int b, int expected) => AssertThat(a + b).IsEqual(expected);
+
+    [TestCase]
+    [DataPoint(nameof(AsyncSingleDataPoint))]
+    public void OnAsyncSingleDataPoint(int a) => AssertThat(a).IsBetween(1, 3);
+
+
+    [TestCase(Timeout = 100)]
+    [DataPoint(nameof(AsyncArrayDataPointBlocked))]
+    public void OnAsyncArrayDataPointFailByTimeout(int a, int b, int expected) => AssertThat(a + b).IsEqual(expected);
+
+    #endregion
+}

--- a/test/src/core/TestSuiteWithExpectedExceptions.cs
+++ b/test/src/core/TestSuiteWithExpectedExceptions.cs
@@ -1,0 +1,41 @@
+﻿namespace GdUnit4.Tests.Core;
+
+using System;
+using System.Threading.Tasks;
+
+using GdUnit4.Core.Execution.Exceptions;
+
+using static Assertions;
+
+[TestSuite]
+public class TestSuiteWithExpectedExceptions
+{
+    [TestCase(Timeout = 100)]
+    [ThrowsException(typeof(ExecutionTimeoutException), "The execution has timed out after 100ms.")]
+    public async Task ExpectExecutionTimeoutException()
+    {
+        await Task.Delay(500);
+        // will never be executed because the test is interrupted after a timeout of 100ms
+        AssertBool(true).IsFalse();
+    }
+
+    [TestCase]
+    [ThrowsException(typeof(TestFailedException), "Expecting: 'False' but is 'True'")]
+    public void ExpectTestFailedException() =>
+        AssertBool(true).IsFalse();
+
+
+    [TestCase]
+    [ThrowsException(typeof(ArgumentException), "The argument 'message' is invalid")]
+    public void ExpectArgumentException() =>
+        throw new ArgumentException("The argument 'message' is invalid");
+
+    [TestCase]
+    [ThrowsException(typeof(ArgumentNullException))]
+    public void ExpectNullException()
+    {
+        string? value = null;
+        // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
+        value!.Contains(""); // This will throw ArgumentNullException
+    }
+}


### PR DESCRIPTION
# why
https://github.com/MikeSchulze/gdUnit4Net/issues/46

# what
added  `DataPointAttribute` to full support RFC 006 - DynamicData

# Examples:
```cs
    public static IEnumerable<object[]> ArrayDataPointProperty => new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 9 } };

    [TestCase]
    [DataPoint(nameof(ArrayDataPointProperty))]
    public void OnArrayDataPointProperty(int a, int b, int expected) => AssertThat(a + b).IsEqual(expected);
```
```cs
    public static IEnumerable<int> SingleDataPointProperty => new[] { 1, 2, 3 };
    
    [TestCase]
    [DataPoint(nameof(SingleDataPointProperty))]
    public void OnSingleDataPointProperty(int value) => AssertThat(value).IsBetween(1, 3);
```
```cs
    public static IEnumerable<object[]> ArrayDataPointMethod() => new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 9 } };

    [TestCase]
    [DataPoint(nameof(ArrayDataPointMethod))]
    public void OnArrayDataPointMethod(int a, int b, int expected) => AssertThat(a + b).IsEqual(expected);
```
```cs
    // async
    public static async IAsyncEnumerable<object?[]> AsyncArrayDataPoint()
    {
        for (var i = 0; i < 3; i++)
        {
            // Simulate async work for each item
            await Task.Delay(10);
            yield return new object?[] { i, i + 1, i + i + 1 };
        }
    }

    [TestCase]
    [DataPoint(nameof(AsyncArrayDataPoint))]
    public void OnAsyncArrayDataPoint(int a, int b, int expected) => AssertThat(a + b).IsEqual(expected);

```
```cs    
    public static IEnumerable<object[]> DataFactory(int factor) => new[] { new object[] { 1 * factor, 1 * factor }, new object[] { 2 * factor, 2 * factor } };
    
    [TestCase]
    [DataPoint(nameof(DataFactory), 2)]
    public void ParameterizedPublicDataPoint(int value, int expected) => AssertThat(value).IsEqual(expected);
````

- Added `ThrowsException` attribute for internal testing only to verify a test is failing by specific exception.
  This allows me to simply verify the test is failed, e.g. by a timeout exception.
- set version to release candidate `rc3`