### PR TITLE
GD-156: Install Godot exception handler and forward uncaught exceptions as test failure.

### DIFF
--- a/api/src/api/TestRunner.cs
+++ b/api/src/api/TestRunner.cs
@@ -11,7 +11,6 @@ using CommandLine;
 using Core;
 using Core.Events;
 using Core.Execution;
-using Core.Hooks;
 
 using Godot;
 
@@ -60,8 +59,6 @@ public partial class TestRunner : Node
                 return -1;
             }
 
-            // install exception hook to catch exceptions that swallowed by the Godot exception handler
-            using var exceptionHook = GodotExceptionHook.Instance;
             using Executor executor = new();
             executor.AddTestEventListener(listener);
 

--- a/api/src/core/DebuggerUtils.cs
+++ b/api/src/core/DebuggerUtils.cs
@@ -1,0 +1,26 @@
+﻿namespace GdUnit4.Core;
+
+using System.Reflection;
+
+using Godot.NativeInterop;
+
+internal static class DebuggerUtils
+{
+    private static readonly MethodInfo? DebuggerIsActiveMethod;
+
+    static DebuggerUtils()
+    {
+        var nativeFuncType = typeof(NativeFuncs);
+        DebuggerIsActiveMethod = nativeFuncType.GetMethod("godotsharp_internal_script_debugger_is_active",
+            BindingFlags.NonPublic | BindingFlags.Static);
+    }
+
+    public static bool IsDebuggerActive()
+    {
+        if (DebuggerIsActiveMethod == null)
+            return false;
+
+        var isDebuggerActive = (godot_bool)DebuggerIsActiveMethod.Invoke(null, null)!;
+        return isDebuggerActive.ToBool();
+    }
+}

--- a/api/src/core/execution/monitoring/ErrorLogEntry.cs
+++ b/api/src/core/execution/monitoring/ErrorLogEntry.cs
@@ -1,0 +1,118 @@
+﻿namespace GdUnit4.Core.Execution.Monitoring;
+
+using System;
+using System.Text.RegularExpressions;
+
+using Godot;
+
+internal sealed partial class ErrorLogEntry
+{
+    public enum ErrorType
+    {
+        Exception,
+        PushError,
+        PushWarning
+    }
+
+    private const string PATTERN_SCRIPT_ERROR = "USER SCRIPT ERROR:";
+    private const string PATTERN_PUSH_ERROR = "USER ERROR:";
+    private const string PATTERN_PUSH_WARNING = "USER WARNING:";
+
+    // With Godot 4.4 the pattern has changed
+    private const string PATTERN_4_X4_EXCEPTION = "ERROR:";
+    private const string PATTERN_4_X4_PUSH_ERROR = "USER ERROR:";
+    private const string PATTERN_4_X4_PUSH_WARNING = "USER WARNING:";
+    private static readonly Regex ExceptionPatternDebugMode = ExceptionPatternDebugRegex();
+    private static readonly Regex ExceptionPatternReleaseMode = ExceptionPatternReleaseRegex();
+
+    private ErrorLogEntry(ErrorType entryType, string message, string details, Type? exceptionType = null)
+    {
+        EntryType = entryType;
+        Message = message;
+        Details = details;
+        ExceptionType = exceptionType;
+    }
+
+    internal string Details { get; }
+    internal string Message { get; }
+    internal ErrorType EntryType { get; }
+    internal Type? ExceptionType { get; }
+
+    // Cache the Godot version check result
+    private static bool IsGodot4X4 { get; } = (int)Engine.GetVersionInfo()["hex"] >= 0x40300;
+
+    private static bool IsDebuggerActive { get; } = DebuggerUtils.IsDebuggerActive();
+
+    public static ErrorLogEntry? ExtractPushWarning(string[] records, int index) =>
+        Extract(records, index, ErrorType.PushWarning, IsGodot4X4 ? PATTERN_4_X4_PUSH_WARNING : PATTERN_PUSH_WARNING);
+
+    public static ErrorLogEntry? ExtractPushError(string[] records, int index) =>
+        Extract(records, index, ErrorType.PushError, IsGodot4X4 ? PATTERN_4_X4_PUSH_ERROR : PATTERN_PUSH_ERROR);
+
+    public static ErrorLogEntry? ExtractException(string[] records, int index)
+    {
+        var pattern = IsDebuggerActive ? PATTERN_4_X4_EXCEPTION : PATTERN_4_X4_PUSH_ERROR;
+
+        return Extract(records, index, ErrorType.Exception, pattern);
+    }
+
+    private static Type? TryGetExceptionType(string typeName)
+    {
+        try
+        {
+            // First try to get the type directly
+            var type = Type.GetType(typeName, false, true);
+            if (type != null && typeof(Exception).IsAssignableFrom(type))
+                return type;
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            GD.PrintErr($"Failed to resolve exception type '{typeName}': {ex.Message}");
+            return null;
+        }
+    }
+
+    private static ErrorLogEntry? Extract(string[] records, int index, ErrorType type, string pattern)
+    {
+        if (index >= records.Length)
+            return null;
+
+        var record = records[index];
+        if (!record.StartsWith(pattern))
+            return null;
+
+        // Remove the pattern and trim whitespace
+        var content = record.Replace(pattern, "").Trim();
+        // Get the details from the next line if available
+        var details = index + 1 < records.Length ? records[index + 1].Trim() : string.Empty;
+
+        // Handle exception type parsing
+        if (type == ErrorType.Exception)
+        {
+            var match = IsDebuggerActive ? ExceptionPatternDebugMode.Match(content) : ExceptionPatternReleaseMode.Match(content);
+            if (match.Success)
+            {
+                var exceptionTypeName = match.Groups[1].Value;
+                var exceptionMessage = match.Groups[2].Value;
+                var exceptionType = TryGetExceptionType(exceptionTypeName);
+                return new ErrorLogEntry(type, exceptionMessage, details, exceptionType);
+            }
+        }
+
+        return new ErrorLogEntry(type, content, details);
+    }
+
+    public override string ToString() =>
+        EntryType == ErrorType.Exception
+            ? $"{EntryType}: [{ExceptionType?.Name ?? "Unknown Exception"}] {Message}\nDetails: {Details}"
+            : $"{EntryType}: {Message}\nDetails: {Details}";
+
+    [GeneratedRegex(@"'([\w\.]+Exception):\s*(.*)'", RegexOptions.Compiled)]
+    private static partial Regex ExceptionPatternDebugRegex();
+
+
+    [GeneratedRegex(@"([\w\.]+Exception):\s*(.*?)(?:\r\n|\n|$)", RegexOptions.Compiled)]
+    private static partial Regex ExceptionPatternReleaseRegex();
+}

--- a/api/src/core/execution/monitoring/GodotExceptionMonitor.cs
+++ b/api/src/core/execution/monitoring/GodotExceptionMonitor.cs
@@ -1,0 +1,180 @@
+﻿namespace GdUnit4.Core.Execution.Monitoring;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
+
+using Exceptions;
+
+using Godot;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using FileAccess = System.IO.FileAccess;
+
+public class GodotExceptionMonitor
+{
+    // Types of exceptions that should be ignored during test execution
+    private static readonly HashSet<Type> IgnoredExceptionTypes = new()
+    {
+        typeof(TestFailedException),
+        typeof(AssertFailedException),
+        typeof(UnitTestAssertException)
+    };
+
+    private static readonly List<Exception> CaughtExceptions = new();
+
+    private readonly string godotLogFile;
+    private long eof;
+
+    public GodotExceptionMonitor(string godotLogFile) => this.godotLogFile = godotLogFile;
+
+    public void Start()
+    {
+        AppDomain.CurrentDomain.FirstChanceException += OnFirstChanceException;
+
+        try
+        {
+            using var fileStream = new FileStream(godotLogFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(fileStream);
+            fileStream.Seek(0, SeekOrigin.End);
+            eof = fileStream.Length;
+        }
+        catch (IOException ex)
+        {
+            GD.PrintErr($"Failed to open log file: {ex.Message}");
+        }
+    }
+
+    public async Task Stop()
+    {
+        var tree = Engine.GetMainLoop() as SceneTree;
+        await tree!.ToSignal(tree, SceneTree.SignalName.ProcessFrame);
+        await tree.ToSignal(tree, SceneTree.SignalName.PhysicsFrame);
+
+        AppDomain.CurrentDomain.FirstChanceException -= OnFirstChanceException;
+
+        if (CaughtExceptions.Count == 0)
+            return;
+
+        try
+        {
+            foreach (var logEntry in ScanGodotLogFile())
+                switch (logEntry.EntryType)
+                {
+                    case ErrorLogEntry.ErrorType.Exception:
+                        var exception = CaughtExceptions.FirstOrDefault(e => e.GetType() == logEntry.ExceptionType && e.Message == logEntry.Message);
+                        if (exception != null)
+                            ExceptionDispatchInfo.Capture(exception).Throw();
+                        break;
+                    case ErrorLogEntry.ErrorType.PushError:
+                        throw new TestFailedException(logEntry.Message);
+                        break;
+                    case ErrorLogEntry.ErrorType.PushWarning:
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+        }
+        finally
+        {
+            CaughtExceptions.Clear();
+        }
+    }
+
+    private void OnFirstChanceException(object? sender, FirstChanceExceptionEventArgs e)
+    {
+        if (ShouldIgnoreException(e.Exception))
+            return;
+        if (IsSceneProcessing()) CaughtExceptions.Add(e.Exception);
+    }
+
+    private static bool ShouldIgnoreException(Exception ex)
+    {
+        if (ex is TargetInvocationException)
+        {
+            var ei = ExceptionDispatchInfo.Capture(ex.InnerException ?? ex);
+            return ShouldIgnoreException(ei.SourceException);
+        }
+
+        return IgnoredExceptionTypes.Contains(ex.GetType());
+    }
+
+    private static bool IsSceneProcessing()
+    {
+        // Look for scene processing methods in the stack trace
+        var stackTrace = new StackTrace(true);
+        foreach (var frame in stackTrace.GetFrames())
+        {
+            var method = frame.GetMethod();
+            if (method == null) continue;
+
+            var declaringType = method.DeclaringType;
+            if (declaringType == null) continue;
+
+            // Check for scene processing methods
+            if (IsSceneProcessingMethod(method.Name, declaringType))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsSceneProcessingMethod(string methodName, Type declaringType)
+    {
+        // Check for common Godot processing methods
+        if (methodName is "_Process" or "_PhysicsProcess" or "_Input" or "_UnhandledInput" or "_Ready")
+            // Check if the declaring type is or inherits from Node
+            return typeof(Node).IsAssignableFrom(declaringType) || typeof(RefCounted).IsAssignableFrom(declaringType);
+        return false;
+    }
+
+    private List<ErrorLogEntry> ScanGodotLogFile()
+    {
+        var logEntries = new List<ErrorLogEntry?>();
+        try
+        {
+            using var fileStream = new FileStream(godotLogFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(fileStream);
+
+            // Seek to the last known position
+            fileStream.Seek(eof, SeekOrigin.Begin);
+
+            var records = new List<string>();
+            while (reader.ReadLine() is { } line) records.Add(line);
+
+            // Update the EOF position
+            eof = fileStream.Position;
+
+            for (var index = 0; index < records.Count; index++)
+            {
+                var extractException = ErrorLogEntry.ExtractException(records.ToArray(), index);
+                if (extractException != null)
+                {
+                    logEntries.Add(extractException);
+                    continue;
+                }
+
+                var extractPushError = ErrorLogEntry.ExtractPushError(records.ToArray(), index);
+                if (extractPushError != null)
+                {
+                    logEntries.Add(extractPushError);
+                    continue;
+                }
+
+                logEntries.Add(ErrorLogEntry.ExtractPushWarning(records.ToArray(), index));
+            }
+        }
+        catch (IOException ex)
+        {
+            GD.PrintErr($"Failed to read log file: {ex.Message}");
+        }
+
+        return logEntries.Where(e => e != null).ToList()!;
+    }
+}

--- a/test/src/core/hooks/GodotExceptionHookTest.cs
+++ b/test/src/core/hooks/GodotExceptionHookTest.cs
@@ -37,6 +37,9 @@ public partial class GodotExceptionHookTest
         runner.Invoke("SomeMethodThatThrowsException");
     }
 
+    [TestCase]
+    public void PrintGodotVersion() => Console.WriteLine(Engine.GetVersionInfo()["string"]);
+
     // Test class to verify the interceptor
     public partial class TestNode : Node
     {

--- a/test/src/core/resources/scenes/TestSceneWithExceptionTest.cs
+++ b/test/src/core/resources/scenes/TestSceneWithExceptionTest.cs
@@ -19,6 +19,16 @@ public partial class TestSceneWithExceptionTest : Control
         // we throw an example exception
         if (frameCount == 10)
             throw new InvalidProgramException("Exception during scene processing");
+        try
+        {
+            if (frameCount == 5)
+                throw new InvalidProgramException("Exception during scene processing inside a catch block");
+        }
+        catch (InvalidProgramException)
+        {
+            // ignore
+        }
+
         frameCount++;
     }
 }

--- a/testadapter/src/execution/TestExecutor.cs
+++ b/testadapter/src/execution/TestExecutor.cs
@@ -103,7 +103,7 @@ internal sealed class TestExecutor : BaseTestExecutor, ITestExecutor
         //    : testCases;
         var testRunnerScene = "res://gdunit4_testadapter/TestAdapterRunner.tscn";
         //  --log-file godot.log
-        var arguments = $"{debugArg} --path . {testRunnerScene} --testadapter --configfile=\"{configName}\" {gdUnit4Settings.Parameters}";
+        var arguments = $"{debugArg} --path . {testRunnerScene} --testadapter --configfile=\"{configName}\" {gdUnit4Settings.Parameters} --log-file godot.log";
         frameworkHandle.SendMessage(TestMessageLevel.Informational, @$"Run with args {arguments}");
         var processStartInfo = new ProcessStartInfo(@$"{GodotBin}", arguments)
         {


### PR DESCRIPTION
# Why
Continuation of GD-156, the we want to only report uncaught exceptions.

# What
Replaced the `GodotExceptionHook ` by a `GodotExceptionMonitor` to catch exceptions and validate against the Godot logs if the exception uncaught.