### PR TITLE
GD-163: Collect the Godot log file into test report

### DIFF
--- a/.github/actions/upload-test-report/action.yml
+++ b/.github/actions/upload-test-report/action.yml
@@ -15,9 +15,9 @@ runs:
         retention-days: 10
         name: artifact_${{ inputs.report-name }}
         path: |
-          ./test/TestResults/test-result.trx
+          ./test/TestResults/**
           ./test/reports/**
-          ./example/TestResults/test-result.trx
+          ./example/TestResults/**
           ./example/reports/**
           /var/lib/systemd/coredump/**
           /var/log/syslog

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -112,13 +112,6 @@ jobs:
           xvfb-run --auto-servernum dotnet test ./test/gdUnit4Test.csproj --no-build --settings ./test/.runsettings-ci --verbosity normal
         # -verbosity:diag --blame
 
-      - name: "debug"
-        shell: bash
-        run: |
-          echo "list content"
-          tree
-          find /home -name godot.log
-
       - name: "Upload Unit Test Reports"
         if: ${{ !cancelled() }}
         uses: ./.github/actions/upload-test-report

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -112,6 +112,13 @@ jobs:
           xvfb-run --auto-servernum dotnet test ./test/gdUnit4Test.csproj --no-build --settings ./test/.runsettings-ci --verbosity normal
         # -verbosity:diag --blame
 
+      - name: "debug"
+        shell: bash
+        run: |
+          echo "list content"
+          tree
+          find /home -name godot.log
+
       - name: "Upload Unit Test Reports"
         if: ${{ !cancelled() }}
         uses: ./.github/actions/upload-test-report

--- a/testadapter.test/gdUnit4TestAdapter.Tests.csproj
+++ b/testadapter.test/gdUnit4TestAdapter.Tests.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>11.0</LangVersion>
     <IsPackable>false</IsPackable>
-    <RootNamespace>GdUnit4.TestAdapter.Test</RootNamespace>
+    <RootNamespace>GdUnit4.TestAdapter</RootNamespace>
 
     <AssemblyName>gdUnit4.TestAdapter.Test</AssemblyName>
     <!-- warning CS8785, prevent Godot ScriptPathAttributeGenerator errors-->

--- a/testadapter.test/test/TestUtils.cs
+++ b/testadapter.test/test/TestUtils.cs
@@ -1,0 +1,14 @@
+﻿namespace GdUnit4.TestAdapter.Test;
+
+using System;
+using System.IO;
+
+public static class TestUtils
+{
+    public static string GetResourcePath(string resourcePath)
+    {
+        var baseDir = AppDomain.CurrentDomain.BaseDirectory;
+        var projectRoot = Path.GetFullPath(Path.Combine(baseDir, "..", "..", ".."));
+        return Path.Combine(projectRoot, "test", "resources", resourcePath);
+    }
+}

--- a/testadapter.test/test/resources/project.godot
+++ b/testadapter.test/test/resources/project.godot
@@ -1,0 +1,19 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="gdUnit4Test"
+config/features=PackedStringArray("4.3", "C#", "Forward Plus")
+config/icon="res://icon.svg"
+
+[dotnet]
+
+project/assembly_name="gdUnit4Test"

--- a/testadapter.test/test/resources/project.godot2
+++ b/testadapter.test/test/resources/project.godot2
@@ -1,0 +1,83 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="gdUnit4"
+config/tags=PackedStringArray("addon", "godot4", "testing")
+config/features=PackedStringArray("4.3", "C#")
+config/icon="res://icon.png"
+
+[audio]
+
+default_bus_layout=""
+
+[debug]
+
+file_logging/log_path="res://godot_session.log"
+gdscript/warnings/exclude_addons=false
+gdscript/warnings/untyped_declaration=2
+gdscript/warnings/unsafe_property_access=1
+gdscript/warnings/unsafe_method_access=1
+gdscript/warnings/unsafe_cast=1
+gdscript/warnings/unsafe_call_argument=1
+
+[dotnet]
+
+project/assembly_name="gdUnit4"
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/gdUnit4/plugin.cfg")
+
+[gdunit4]
+
+ui/inspector/node_collapse=false
+ui/toolbar/run_overall=true
+ui/inspector/tree_sort_mode=1
+report/godot/script_error=false
+settings/test/flaky_check_enable=true
+settings/common/update_notification_enabled=false
+
+[importer_defaults]
+
+texture={
+"compress/channel_pack": 0,
+"compress/hdr_compression": 1,
+"compress/high_quality": false,
+"compress/lossy_quality": 0.7,
+"compress/mode": 0,
+"compress/normal_map": 0,
+"detect_3d/compress_to": 1,
+"editor/convert_colors_with_editor_theme": true,
+"editor/scale_with_editor_scale": true,
+"mipmaps/generate": false,
+"mipmaps/limit": -1,
+"process/fix_alpha_border": true,
+"process/hdr_as_srgb": false,
+"process/hdr_clamp_exposure": false,
+"process/normal_map_invert_y": false,
+"process/premult_alpha": false,
+"process/size_limit": 0,
+"roughness/mode": 0,
+"roughness/src_normal": "",
+"svg/scale": 1.0
+}
+
+[network]
+
+limits/debugger_stdout/max_chars_per_second=60048
+limits/debugger_stdout/max_messages_per_frame=100
+limits/debugger_stdout/max_errors_per_second=1000
+limits/debugger_stdout/max_warnings_per_second=1000
+
+[rendering]
+
+environment/default_environment="res://default_env.tres"

--- a/testadapter.test/test/settings/GodotProjectSettingsTest.cs
+++ b/testadapter.test/test/settings/GodotProjectSettingsTest.cs
@@ -1,0 +1,65 @@
+﻿namespace GdUnit4.TestAdapter.Test.Settings;
+
+using System;
+using System.IO;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using TestAdapter.Settings;
+
+using static TestUtils;
+
+using static Utilities.Utils;
+
+[TestClass]
+public class GodotProjectSettingsTest
+{
+    [TestMethod]
+    public void GlobalizeGodotPath()
+    {
+        // user specific path
+        Assert.AreEqual(
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Godot", "app_userdata", "gdUnit4Test", "logs", "godot.log"),
+            GodotProjectSettings.GlobalizeGodotPath("user://logs/godot.log", "gdUnit4Test"));
+        // project specific path
+        Assert.AreEqual(
+            Path.Combine(GetProjectRoot(), "logs", "godot.log"),
+            GodotProjectSettings.GlobalizeGodotPath("res://logs/godot.log", "gdUnit4Test"));
+    }
+
+    [TestMethod]
+    public void LoadGodotProjectSettingsWithoutDebugSection()
+    {
+        var projectFile = GetResourcePath("project.godot");
+        var settings = GodotProjectSettings.LoadFromFile(projectFile);
+        Assert.IsNotNull(settings);
+
+        Assert.AreEqual("gdUnit4Test", settings.Application.Config.Name);
+        CollectionAssert.Contains(settings.Application.Config.Features, "4.3");
+        CollectionAssert.Contains(settings.Application.Config.Features, "C#");
+        Assert.AreEqual("res://icon.svg", settings.Application.Config.Icon);
+
+        // validate the log file path points to the default user dir
+        Assert.IsNotNull(settings.Debug);
+        var expectedLogFilePath = GodotProjectSettings.GlobalizeGodotPath("user://logs/godot.log", "gdUnit4Test");
+        Assert.AreEqual(expectedLogFilePath, settings.Debug.FileLogging.LogPath);
+    }
+
+    [TestMethod]
+    public void LoadGodotProjectSettingsWithCustomLogPath()
+    {
+        var projectFile = GetResourcePath("project.godot2");
+        var settings = GodotProjectSettings.LoadFromFile(projectFile);
+        Assert.IsNotNull(settings);
+
+        Assert.AreEqual("gdUnit4", settings.Application.Config.Name);
+        CollectionAssert.Contains(settings.Application.Config.Features, "4.3");
+        CollectionAssert.Contains(settings.Application.Config.Features, "C#");
+        Assert.AreEqual("res://icon.png", settings.Application.Config.Icon);
+
+        // validate the log file path points to project root
+        Assert.IsNotNull(settings.Debug);
+        var expectedLogFilePath = Path.Combine(GetProjectRoot(), "godot_session.log");
+        Assert.AreEqual(expectedLogFilePath, settings.Debug.FileLogging.LogPath);
+    }
+}

--- a/testadapter.test/test/settings/GodotProjectSettingsTest.cs
+++ b/testadapter.test/test/settings/GodotProjectSettingsTest.cs
@@ -1,6 +1,5 @@
 ﻿namespace GdUnit4.TestAdapter.Test.Settings;
 
-using System;
 using System.IO;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -9,7 +8,7 @@ using TestAdapter.Settings;
 
 using static TestUtils;
 
-using static Utilities.Utils;
+using static TestAdapter.Utilities.Utils;
 
 [TestClass]
 public class GodotProjectSettingsTest
@@ -19,11 +18,11 @@ public class GodotProjectSettingsTest
     {
         // user specific path
         Assert.AreEqual(
-            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Godot", "app_userdata", "gdUnit4Test", "logs", "godot.log"),
+            Path.Combine(GetUserDataDirectory, "app_userdata", "gdUnit4Test", "logs", "godot.log"),
             GodotProjectSettings.GlobalizeGodotPath("user://logs/godot.log", "gdUnit4Test"));
         // project specific path
         Assert.AreEqual(
-            Path.Combine(GetProjectRoot(), "logs", "godot.log"),
+            Path.Combine(GetProjectDirectory, "logs", "godot.log"),
             GodotProjectSettings.GlobalizeGodotPath("res://logs/godot.log", "gdUnit4Test"));
     }
 
@@ -59,7 +58,7 @@ public class GodotProjectSettingsTest
 
         // validate the log file path points to project root
         Assert.IsNotNull(settings.Debug);
-        var expectedLogFilePath = Path.Combine(GetProjectRoot(), "godot_session.log");
+        var expectedLogFilePath = Path.Combine(GetProjectDirectory, "godot_session.log");
         Assert.AreEqual(expectedLogFilePath, settings.Debug.FileLogging.LogPath);
     }
 }

--- a/testadapter.test/test/settings/RunSettingsProviderTest.cs
+++ b/testadapter.test/test/settings/RunSettingsProviderTest.cs
@@ -1,10 +1,10 @@
-﻿namespace GdUnit4.TestAdapter.Test.settings;
+﻿namespace GdUnit4.TestAdapter.Test.Settings;
 
 using System.Collections.Generic;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using Settings;
+using TestAdapter.Settings;
 
 [TestClass]
 public class RunSettingsProviderTest

--- a/testadapter.test/test/utilities/UtilsTest.cs
+++ b/testadapter.test/test/utilities/UtilsTest.cs
@@ -1,0 +1,30 @@
+﻿namespace GdUnit4.TestAdapter.Test.Utilities;
+
+using System;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using static TestAdapter.Utilities.Utils;
+
+[TestClass]
+public class UtilsTest
+{
+    [TestMethod]
+    public void ProjectDirectory()
+        => Assert.IsTrue(GetProjectDirectory.EndsWith("testadapter.test"));
+
+    [TestMethod]
+    public void UserDataDirectory()
+    {
+        switch (Environment.OSVersion.Platform)
+        {
+            case PlatformID.Win32NT:
+                Assert.IsTrue(GetUserDataDirectory.EndsWith("Godot")); break;
+            case PlatformID.Unix:
+                Assert.IsTrue(GetUserDataDirectory.EndsWith("godot")); break;
+            case PlatformID.MacOSX:
+                Assert.IsTrue(GetUserDataDirectory.EndsWith("Library/Application Support/Godot"));
+                break;
+        }
+    }
+}

--- a/testadapter/src/settings/GodotProjectSettings.cs
+++ b/testadapter/src/settings/GodotProjectSettings.cs
@@ -139,16 +139,13 @@ internal class GodotProjectSettings
 
     internal static string GlobalizeGodotPath(string path, string projectName)
     {
-        // Handle user specific paths
-        if (path.StartsWith("user://"))
-        {
-            var userPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            return path.Replace("user:/", Path.Combine(userPath, "Godot", "app_userdata", projectName)).Replace("/", Path.DirectorySeparatorChar.ToString());
-        }
+        if (!path.StartsWith("user://") && !path.StartsWith("res://"))
+            return path;
 
-        return path.StartsWith("res://")
-            ? path.Replace("res:/", Utils.GetProjectRoot()).Replace("/", Path.DirectorySeparatorChar.ToString())
-            : path;
+        return path
+            .Replace("user:/", Path.Combine(Utils.GetUserDataDirectory, "app_userdata", projectName))
+            .Replace("res:/", Utils.GetProjectDirectory)
+            .Replace("/", Path.DirectorySeparatorChar.ToString());
     }
 
 

--- a/testadapter/src/settings/GodotProjectSettings.cs
+++ b/testadapter/src/settings/GodotProjectSettings.cs
@@ -1,0 +1,215 @@
+﻿// ReSharper disable MemberCanBePrivate.Global
+
+namespace GdUnit4.TestAdapter.Settings;
+
+using System;
+using System.IO;
+using System.Linq;
+
+using Utilities;
+
+internal class GodotProjectSettings
+{
+    internal ApplicationSection Application { get; set; } = new();
+    internal DebugSection Debug { get; set; } = new();
+    internal EditorPluginsSection EditorPlugins { get; set; } = new();
+    internal GdUnit4Section GdUnit4 { get; set; } = new();
+
+    internal static GodotProjectSettings LoadFromFile(string filePath)
+    {
+        var settings = new GodotProjectSettings();
+        var lines = File.ReadAllLines(filePath);
+
+        var currentSection = "";
+        foreach (var line in lines)
+        {
+            var trimmedLine = line.Trim();
+
+            if (string.IsNullOrWhiteSpace(trimmedLine) || trimmedLine.StartsWith(';'))
+                continue;
+
+            if (trimmedLine.StartsWith('[') && trimmedLine.EndsWith(']'))
+            {
+                currentSection = trimmedLine.Substring(1, trimmedLine.Length - 2);
+                continue;
+            }
+
+            if (currentSection == "" || !trimmedLine.Contains('='))
+                continue;
+
+            var parts = trimmedLine.Split(new[] { '=' }, 2);
+            if (parts.Length == 2)
+            {
+                var key = parts[0].Trim();
+                var value = ParseValue(parts[1].Trim());
+                SetPropertyValue(settings, currentSection, key, value);
+            }
+        }
+
+        // fix godot paths to system paths
+        settings.Debug.FileLogging.LogPath =
+            GlobalizeGodotPath(settings.Debug.FileLogging.LogPath, settings.Application.Config.Name);
+
+        return settings;
+    }
+
+    private static void SetPropertyValue(GodotProjectSettings settings, string section, string key, object value)
+    {
+        object? sectionObj = section.ToLower() switch
+        {
+            "application" => settings.Application,
+            "debug" => settings.Debug,
+            "editor_plugins" => settings.EditorPlugins,
+            "gdunit4" => settings.GdUnit4,
+            _ => null
+        };
+
+        if (sectionObj == null) return;
+
+        var propertyParts = key.Split('/');
+        var currentObj = sectionObj;
+
+        for (var i = 0; i < propertyParts.Length - 1; i++)
+        {
+            var propertyName = ToPascalCase(propertyParts[i]);
+            var property = currentObj.GetType().GetProperty(propertyName);
+
+            if (property == null)
+                return;
+
+            currentObj = property.GetValue(currentObj);
+            if (currentObj == null)
+                return;
+        }
+
+        var finalPropertyName = ToPascalCase(propertyParts[^1]);
+        var finalProperty = currentObj.GetType().GetProperty(finalPropertyName);
+
+        if (finalProperty != null)
+            try
+            {
+                if (finalProperty.PropertyType.IsArray)
+                {
+                    if (value is string[] arrayValue)
+                        finalProperty.SetValue(currentObj, arrayValue);
+                }
+                else
+                {
+                    var convertedValue = Convert.ChangeType(value, finalProperty.PropertyType);
+                    finalProperty.SetValue(currentObj, convertedValue);
+                }
+            }
+            catch (Exception)
+            {
+                // Log or handle conversion errors
+            }
+    }
+
+    private static string ToPascalCase(string input)
+    {
+        var words = input.Split('_', StringSplitOptions.RemoveEmptyEntries);
+        return string.Concat(words.Select(word =>
+            char.ToUpper(word[0]) +
+            (word.Length > 1 ? word.Substring(1).ToLower() : "")
+        ));
+    }
+
+    private static object ParseValue(string value)
+    {
+        if (value.StartsWith('"') && value.EndsWith('"'))
+            return value.Substring(1, value.Length - 2);
+
+        if (value.StartsWith("PackedStringArray(") && value.EndsWith(')'))
+        {
+            var arrayContent = value.Substring("PackedStringArray(".Length, value.Length - "PackedStringArray(".Length - 1);
+            return arrayContent.Split(',')
+                .Select(s => s.Trim().Trim('"'))
+                .ToArray();
+        }
+
+        if (bool.TryParse(value.ToLower(), out var boolResult))
+            return boolResult;
+
+        if (double.TryParse(value, out var doubleResult))
+            return doubleResult;
+
+        return value;
+    }
+
+
+    internal static string GlobalizeGodotPath(string path, string projectName)
+    {
+        // Handle user specific paths
+        if (path.StartsWith("user://"))
+        {
+            var userPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            return path.Replace("user:/", Path.Combine(userPath, "Godot", "app_userdata", projectName)).Replace("/", Path.DirectorySeparatorChar.ToString());
+        }
+
+        return path.StartsWith("res://")
+            ? path.Replace("res:/", Utils.GetProjectRoot()).Replace("/", Path.DirectorySeparatorChar.ToString())
+            : path;
+    }
+
+
+    public interface ISettingsSection
+    {
+    }
+
+    public class ApplicationSection : ISettingsSection
+    {
+        public ConfigSetting Config { get; set; } = new();
+
+        public class ConfigSetting
+        {
+            public string Name { get; set; } = "";
+            public string[] Tags { get; set; } = Array.Empty<string>();
+            public string[] Features { get; set; } = Array.Empty<string>();
+            public string Icon { get; set; } = "";
+        }
+    }
+
+    public class DebugSection : ISettingsSection
+    {
+        public FileLoggingSettings FileLogging { get; set; } = new();
+
+        public class FileLoggingSettings
+        {
+            public bool EnableFileLogging { get; set; }
+            public string LogPath { get; set; } = "user://logs/godot.log";
+        }
+    }
+
+
+    public class EditorPluginsSection : ISettingsSection
+    {
+        public string[] Enabled { get; set; } = Array.Empty<string>();
+    }
+
+    public class GdUnit4Section : ISettingsSection
+    {
+        public TestRunSettings Settings { get; set; } = new();
+        public ReportSettings Report { get; set; } = new();
+
+
+        public class TestRunSettings
+        {
+            public TestSettings Test { get; set; } = new();
+
+            public class TestSettings
+            {
+                public bool FlakyCheckEnable { get; set; }
+            }
+        }
+
+        public class ReportSettings
+        {
+            public GodotReportSettings Godot { get; set; } = new();
+
+            public class GodotReportSettings
+            {
+                public bool ScriptError { get; set; }
+            }
+        }
+    }
+}

--- a/testadapter/src/utilities/Utils.cs
+++ b/testadapter/src/utilities/Utils.cs
@@ -9,6 +9,32 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 internal static class Utils
 {
+    internal static string GetUserDataDirectory => Environment.OSVersion.Platform switch
+    {
+        PlatformID.Win32NT => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Godot"),
+        PlatformID.Unix => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "godot"),
+        PlatformID.MacOSX => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.Personal), "Library/Application Support/Godot"),
+        _ => throw new PlatformNotSupportedException("Unsupported operating system")
+    };
+
+    internal static string GetProjectDirectory
+    {
+        get
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+            while (directory != null &&
+                   !directory.EnumerateFiles("*.sln").Any() &&
+                   !directory.EnumerateFiles("*.csproj").Any())
+                directory = directory.Parent;
+
+            return directory?.FullName ?? throw new FileNotFoundException($"Could not find project root directory {directory}");
+        }
+    }
+
     internal static bool CheckGdUnit4ApiMinimumRequiredVersion(IMessageLogger logger, Version minVersion)
     {
         var gdUnit4ApiAssembly = Assembly.Load("gdUnit4Api") ?? throw new InvalidOperationException("No 'gdUnit4Api' is installed!");
@@ -21,17 +47,5 @@ internal static class Utils
         }
 
         return true;
-    }
-
-    internal static string GetProjectRoot()
-    {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-
-        while (directory != null &&
-               !directory.EnumerateFiles("*.sln").Any() &&
-               !directory.EnumerateFiles("*.csproj").Any())
-            directory = directory.Parent;
-
-        return directory?.FullName ?? throw new FileNotFoundException($"Could not find project root directory {directory}");
     }
 }

--- a/testadapter/src/utilities/Utils.cs
+++ b/testadapter/src/utilities/Utils.cs
@@ -1,6 +1,8 @@
 namespace GdUnit4.TestAdapter.Utilities;
 
 using System;
+using System.IO;
+using System.Linq;
 using System.Reflection;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -19,5 +21,17 @@ internal static class Utils
         }
 
         return true;
+    }
+
+    internal static string GetProjectRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory != null &&
+               !directory.EnumerateFiles("*.sln").Any() &&
+               !directory.EnumerateFiles("*.csproj").Any())
+            directory = directory.Parent;
+
+        return directory?.FullName ?? throw new FileNotFoundException($"Could not find project root directory {directory}");
     }
 }


### PR DESCRIPTION
# Why
see https://github.com/MikeSchulze/gdUnit4Net/issues/163

# What
- Added `GodotProjectSettings` to load the current project settings
- Copy finally the Godot log file into the results directory