### PR TITLE
GD-152: Preparing test executor to run without Godot engine

### DIFF
--- a/api/src/ISceneRunner.cs
+++ b/api/src/ISceneRunner.cs
@@ -4,6 +4,7 @@ using System;
 using System.Threading.Tasks;
 
 using Core;
+using Core.Extensions;
 
 using Godot;
 
@@ -12,21 +13,16 @@ using Godot;
 /// </summary>
 public interface ISceneRunner : IDisposable
 {
-    internal static SceneTree Instance =>
-        Engine.GetMainLoop() as SceneTree ?? throw new InvalidOperationException("SceneTree is not initialized");
-
     /// <summary>
     ///     A utility to synchronize the current thread with the Godot physics thread.
     ///     This can be used to await the completion of a single physics frame in Godot.
     /// </summary>
-    public static SignalAwaiter SyncProcessFrame =>
-        Instance.ToSignal(Instance, SceneTree.SignalName.ProcessFrame);
+    public static SignalAwaiter SyncProcessFrame => GodotObjectExtensions.SyncProcessFrame;
 
     /// <summary>
     ///     A util to synchronize the current thread with the Godot physics thread
     /// </summary>
-    public static SignalAwaiter SyncPhysicsFrame =>
-        Instance.ToSignal(Instance, SceneTree.SignalName.PhysicsFrame);
+    public static SignalAwaiter SyncPhysicsFrame => GodotObjectExtensions.SyncPhysicsFrame;
 
     /// <summary>
     ///     Loads a scene into the SceneRunner to be simulated.

--- a/api/src/core/GdUnitAwaiter.cs
+++ b/api/src/core/GdUnitAwaiter.cs
@@ -50,7 +50,7 @@ public static class GdUnitAwaiter
         private async Task CallAndWaitIsFinished(Predicate comparator) => await Task.Run(async () =>
         {
             // sync to main thread
-            await ISceneRunner.SyncProcessFrame;
+            await GodotObjectExtensions.SyncProcessFrame;
             var value = await GodotObjectExtensions.Invoke(Instance, MethodName, Args);
             comparator(value);
         });

--- a/api/src/core/execution/AfterTestExecutionStage.cs
+++ b/api/src/core/execution/AfterTestExecutionStage.cs
@@ -22,11 +22,9 @@ internal class AfterTestExecutionStage : ExecutionStage<AfterTestAttribute>
         {
             GodotSignalCollector.Instance.Clean();
             context.MemoryPool.SetActive(StageName);
-            context.OrphanMonitor.Start();
             await base.Execute(context);
-            context.MemoryPool.ReleaseRegisteredObjects();
-            context.OrphanMonitor.Stop();
-            if (context.OrphanMonitor.OrphanCount > 0)
+            await context.MemoryPool.Gc();
+            if (context.MemoryPool.OrphanCount > 0)
                 context.ReportCollector.PushFront(new TestReport(TestReport.ReportType.WARN, 0, ReportOrphans(context)));
         }
 
@@ -52,12 +50,12 @@ internal class AfterTestExecutionStage : ExecutionStage<AfterTestAttribute>
         if (beforeAttribute != null && afterAttributes != null)
             return $"""
                     {AssertFailures.FormatValue("WARNING:", AssertFailures.WARN_COLOR, false)}
-                        Detected <{context.OrphanMonitor.OrphanCount}> orphan nodes during test setup stage!
+                        Detected <{context.MemoryPool.OrphanCount}> orphan nodes during test setup stage!
                         Check [b]{beforeAttribute.Name + ":" + beforeAttribute.Line}[/b] and [b]{afterAttributes.Name + ":" + afterAttributes.Line}[/b] for unfreed instances!
                     """;
         return $"""
                 {AssertFailures.FormatValue("WARNING:", AssertFailures.WARN_COLOR, false)}
-                    Detected <{context.OrphanMonitor.OrphanCount}> orphan nodes during test setup stage!
+                    Detected <{context.MemoryPool.OrphanCount}> orphan nodes during test setup stage!
                     Check [b]{(beforeAttribute != null ? beforeAttribute.Name + ":" + beforeAttribute.Line : afterAttributes?.Name + ":" + afterAttributes?.Line)}[/b] for unfreed instances!
                 """;
     }

--- a/api/src/core/execution/BeforeExecutionStage.cs
+++ b/api/src/core/execution/BeforeExecutionStage.cs
@@ -11,9 +11,8 @@ internal class BeforeExecutionStage : ExecutionStage<BeforeAttribute>
     public override async Task Execute(ExecutionContext context)
     {
         context.FireBeforeEvent();
-        context.MemoryPool.SetActive(StageName);
-        context.OrphanMonitor.Start(true);
+        context.MemoryPool.SetActive(StageName, true);
         await base.Execute(context);
-        context.OrphanMonitor.Stop();
+        context.MemoryPool.StopMonitoring();
     }
 }

--- a/api/src/core/execution/BeforeTestExecutionStage.cs
+++ b/api/src/core/execution/BeforeTestExecutionStage.cs
@@ -13,10 +13,9 @@ internal class BeforeTestExecutionStage : ExecutionStage<BeforeTestAttribute>
         context.FireBeforeTestEvent();
         if (!context.IsSkipped)
         {
-            context.MemoryPool.SetActive(StageName);
-            context.OrphanMonitor.Start(true);
+            context.MemoryPool.SetActive(StageName, true);
             await base.Execute(context);
-            context.OrphanMonitor.Stop();
+            context.MemoryPool.StopMonitoring();
         }
     }
 }

--- a/api/src/core/execution/Executor.cs
+++ b/api/src/core/execution/Executor.cs
@@ -92,7 +92,7 @@ public partial class Executor : RefCounted, IExecutor
         {
             if (!ReportOrphanNodesEnabled)
                 Console.WriteLine("Warning!!! Reporting orphan nodes is disabled. Please check GdUnit settings.");
-            await ISceneRunner.SyncProcessFrame;
+            await GodotObjectExtensions.SyncProcessFrame;
             using ExecutionContext context = new(testSuite, eventListeners, ReportOrphanNodesEnabled);
             context.IsCaptureStdOut = runnerConfig.CaptureStdOut;
             await new TestSuiteExecutionStage(testSuite).Execute(context);

--- a/api/src/core/execution/TestSuiteExecutionStage.cs
+++ b/api/src/core/execution/TestSuiteExecutionStage.cs
@@ -54,7 +54,6 @@ internal sealed class TestSuiteExecutionStage : IExecutionStage
                 else
                     await RunTestCase(stdoutHook, testCaseContext, testCase, testCase.TestCaseAttribute, testCase.Arguments);
 
-
                 if (testCaseContext.IsFailed || testCaseContext.IsError)
                 {
                     //break;

--- a/api/src/core/execution/monitoring/GodotExceptionMonitor.cs
+++ b/api/src/core/execution/monitoring/GodotExceptionMonitor.cs
@@ -11,6 +11,8 @@ using System.Threading.Tasks;
 
 using Exceptions;
 
+using Extensions;
+
 using Godot;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -66,9 +68,8 @@ public class GodotExceptionMonitor
         if (!IsLogFileAvailable)
             return;
 
-        // we need to wait the curren Godot main tread has processed all nodes
-        var tree = Engine.GetMainLoop() as SceneTree;
-        await tree!.ToSignal(tree, SceneTree.SignalName.ProcessFrame);
+        // we need to wait the current Godot main tread has processed all nodes
+        await GodotObjectExtensions.SyncProcessFrame;
 
         try
         {

--- a/api/src/core/execution/monitoring/OrphanNodesMonitor.cs
+++ b/api/src/core/execution/monitoring/OrphanNodesMonitor.cs
@@ -4,31 +4,18 @@ using static Godot.Performance;
 
 internal class OrphanNodesMonitor
 {
-    public OrphanNodesMonitor(bool reportOrphanNodesEnabled)
-        => ReportOrphanNodesEnabled = reportOrphanNodesEnabled;
-
-    private bool ReportOrphanNodesEnabled { get; }
-
     public int OrphanCount { get; private set; }
 
     private int OrphanNodesStart { get; set; }
 
-
     public void Start(bool reset = false)
     {
-        if (ReportOrphanNodesEnabled)
-        {
-            if (reset)
-                Reset();
-            OrphanNodesStart = GetMonitoredOrphanCount();
-        }
+        if (reset)
+            Reset();
+        OrphanNodesStart = GetMonitoredOrphanCount();
     }
 
-    public void Stop()
-    {
-        if (ReportOrphanNodesEnabled)
-            OrphanCount += GetMonitoredOrphanCount() - OrphanNodesStart;
-    }
+    public void Stop() => OrphanCount += GetMonitoredOrphanCount() - OrphanNodesStart;
 
     private int GetMonitoredOrphanCount() => (int)GetMonitor(Monitor.ObjectOrphanNodeCount);
 

--- a/api/src/core/extensions/GodotObjectExtension.cs
+++ b/api/src/core/extensions/GodotObjectExtension.cs
@@ -18,6 +18,22 @@ using Array = Godot.Collections.Array;
 /// </summary>
 internal static class GodotObjectExtensions
 {
+    private static SceneTree Instance =>
+        Engine.GetMainLoop() as SceneTree ?? throw new InvalidOperationException("SceneTree is not initialized");
+
+    /// <summary>
+    ///     A utility to synchronize the current thread with the Godot physics thread.
+    ///     This can be used to await the completion of a single physics frame in Godot.
+    /// </summary>
+    internal static SignalAwaiter SyncProcessFrame =>
+        Instance.ToSignal(Instance, SceneTree.SignalName.ProcessFrame);
+
+    /// <summary>
+    ///     A util to synchronize the current thread with the Godot physics thread
+    /// </summary>
+    internal static SignalAwaiter SyncPhysicsFrame =>
+        Instance.ToSignal(Instance, SceneTree.SignalName.PhysicsFrame);
+
     internal static bool VariantEquals<T>([NotNullWhen(true)] this T? inLeft, T? inRight, Mode compareMode = Mode.CaseSensitive)
     {
         object? left = inLeft.UnboxVariant();
@@ -261,6 +277,7 @@ internal static class GodotObjectExtensions
 
         return result;
     }
+
 
     internal enum Mode
     {


### PR DESCRIPTION
# Why
We need to prepare the test executor to run without any Godot runtime interactions like awaiting for `ProcessFrame` or `PhysicsFrame`

# What
- Moved the `OrphanNodesMonitor ` inside the `MemoryPool` because it stays in relation and should be bundled.
- Simplify `OrphanNodesMonitor `
- Moved `SyncProcessFrame` and `SyncPhysicsFrame` implementaion to `GodotObjectExtensions`