### PR TITLE
GD-152: Part5: Fix test case display name for dynamic test data driven tests

### DIFF
--- a/analyzers.test/src/ExampleTest.cs
+++ b/analyzers.test/src/ExampleTest.cs
@@ -1,0 +1,62 @@
+﻿namespace GdUnit4.Analyzers.Test;
+
+using System.Collections.Generic;
+using System.Reflection;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class ExampleTest
+{
+    [TestMethod]
+    public void SingeTest()
+    {
+    }
+
+    [TestMethod("Test with display name")]
+    public void SingeTestNamed()
+    {
+    }
+
+
+    [TestMethod]
+    [DataRow(1, 2, DisplayName = "DataRow1")]
+    [DataRow(2, 2)]
+    [DataRow(3, 2)]
+    public void DataRowTest(int a, int b)
+    {
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(TestDataProvider.GetTestData), typeof(TestDataProvider), DynamicDataSourceType.Method)]
+    public void TestWithDynamicData(int a, int b, int expected)
+    {
+    }
+
+
+    [TestMethod]
+    [DynamicData(nameof(TestDataProvider.GetTestData), typeof(TestDataProvider), DynamicDataSourceType.Method, DynamicDataDisplayName = "GetDisplayName")]
+    public void TestWithDisplayName(int a, int b, int expected)
+    {
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(TestDataProvider.GetTestData), typeof(TestDataProvider), DynamicDataSourceType.Method)]
+    public void TestWithDisplayName2(int a, int b, int expected)
+    {
+    }
+
+    // Display name provider method
+    public static string GetDisplayName(MethodInfo methodInfo, object[] data)
+        => $"{methodInfo.Name} with {data[0]} + {data[1]} = {data[2]}";
+
+    private class TestDataProvider
+    {
+        public static IEnumerable<object[]> GetTestData()
+        {
+            yield return new object[] { 1, 2, 3 };
+            yield return new object[] { 5, 5, 10 };
+            yield return new object[] { -1, 1, 0 };
+        }
+    }
+}

--- a/api/src/api/ITestEvent.cs
+++ b/api/src/api/ITestEvent.cs
@@ -31,7 +31,15 @@ public interface ITestEvent
     /// </summary>
     Guid Id { get; }
 
-    string FullyQualifiedName { get; set; }
+    /// <summary>
+    ///     The full qualified test name, used for console logging.
+    /// </summary>
+    string FullyQualifiedName { get; }
+
+    /// <summary>
+    ///     The test display name. Used for data driven test e.g. DataPointAttribute
+    /// </summary>
+    string? DisplayName { get; }
 
     /// <summary>
     ///     Gets whether the test failed.

--- a/api/src/core/execution/TestEvent.cs
+++ b/api/src/core/execution/TestEvent.cs
@@ -84,6 +84,8 @@ internal class TestEvent : ITestEvent, IEquatable<TestEvent>
     public bool IsSuccess => !IsWarning && !IsFailed && !IsError && !IsSkipped;
     public TimeSpan ElapsedInMs => TimeSpan.FromMilliseconds(GetByKeyOrDefault(STATISTIC_KEY.ELAPSED_TIME, 0));
 
+    public string? DisplayName { get; set; }
+
     public static TestEvent Before(string resourcePath, string suiteName, int totalCount) =>
         new(ITestEvent.EventType.SuiteBefore, resourcePath, suiteName, "Before", totalCount);
 
@@ -117,6 +119,12 @@ internal class TestEvent : ITestEvent, IEquatable<TestEvent>
     internal TestEvent WithFullyQualifiedName(string name)
     {
         FullyQualifiedName = name;
+        return this;
+    }
+
+    internal TestEvent WithDisplayName(string? name)
+    {
+        DisplayName = name;
         return this;
     }
 

--- a/api/src/core/execution/TestSuiteExecutionStage.cs
+++ b/api/src/core/execution/TestSuiteExecutionStage.cs
@@ -76,7 +76,8 @@ internal sealed class TestSuiteExecutionStage : IExecutionStage
                     var timeout = executionContext.GetExecutionTimeout(testAttribute);
                     await foreach (var dataPointValues in DataPointValueProvider.GetDataAsync(testCase, timeout).ConfigureAwait(false))
                     {
-                        using ExecutionContext testCaseContext = new(executionContext, testCase, testCase.TestCaseAttributes);
+                        var displayName = TestCase.BuildDisplayName(testCase.Name, new TestCaseAttribute(dataPointValues));
+                        using ExecutionContext testCaseContext = new(executionContext, displayName);
                         await RunTestCase(stdoutHook, testCaseContext, testCase, testAttribute, dataPointValues);
                     }
                 }
@@ -93,7 +94,8 @@ internal sealed class TestSuiteExecutionStage : IExecutionStage
             else
                 foreach (var dataPointValues in DataPointValueProvider.GetData(testCase))
                 {
-                    using ExecutionContext testCaseContext = new(executionContext, testCase, testCase.TestCaseAttributes);
+                    var displayName = TestCase.BuildDisplayName(testCase.Name, new TestCaseAttribute(dataPointValues));
+                    using ExecutionContext testCaseContext = new(executionContext, displayName);
                     await RunTestCase(stdoutHook, testCaseContext, testCase, testAttribute, dataPointValues);
                 }
         }

--- a/test/src/core/ExampleTestSuite.cs
+++ b/test/src/core/ExampleTestSuite.cs
@@ -1,8 +1,11 @@
 namespace GdUnit4.Tests.Core;
 
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using static Assertions;
+
 using static Utils;
 
 [TestSuite]
@@ -71,4 +74,25 @@ public sealed class ExampleTestSuite
     [TestCase(true)]
     public void ParameterizedSingleTest(bool value)
         => AssertThat(value).IsTrue();
+
+
+    [TestCase]
+    [IgnoreUntil(Description = "This is an example of ignored test")]
+    public void SkippedTestCase()
+        => Console.WriteLine("SkippedTestCase");
+
+    [TestCase]
+    [DataPoint(nameof(TestDataProvider.GetTestData), typeof(TestDataProvider))]
+    public void TestWithDataPointProperty(int a, int b, int expected)
+        => AssertThat(a + b).IsEqual(expected);
+
+    private class TestDataProvider
+    {
+        public static IEnumerable<object[]> GetTestData()
+        {
+            yield return new object[] { 1, 2, 3 };
+            yield return new object[] { 5, 5, 10 };
+            yield return new object[] { -1, 1, 0 };
+        }
+    }
 }

--- a/test/src/core/GdUnitTestSuiteBuilderTest.cs
+++ b/test/src/core/GdUnitTestSuiteBuilderTest.cs
@@ -242,22 +242,25 @@ public class GdUnitTestSuiteBuilderTest
         AssertThat(testSuite.GetChildren())
             .ExtractV(Extr("Name"), Extr("LineNumber"), Extr("ParameterizedTests"))
             .ContainsExactly(
-                Tuple("TestFoo", 36, new List<string>()),
-                Tuple("TestBar", 44, new List<string>()),
-                Tuple("Waiting", 48, new List<string>()),
-                Tuple("Customized", 52, new List<string>()),
-                Tuple("TestCaseArguments", 58, new List<string>
+                Tuple("TestFoo", 39, new List<string>()),
+                Tuple("TestBar", 47, new List<string>()),
+                Tuple("Waiting", 51, new List<string>()),
+                Tuple("Customized", 55, new List<string>()),
+                Tuple("TestCaseArguments", 61, new List<string>
                 {
                     "TestCaseArguments (1, 2, 3, 6)",
                     "TestCaseArguments (3, 4, 5, 12)",
                     "TestCaseArguments (6, 7, 8, 21)"
                 }),
-                Tuple("TestCasesWithCustomTestName", 64, new List<string>
+                Tuple("TestCasesWithCustomTestName", 67, new List<string>
                 {
                     "TestCaseA (1, 2, 3, 6)",
                     "TestCaseB (3, 4, 5, 12)",
                     "TestCaseC (6, 7, 8, 21)"
                 }),
-                Tuple("ParameterizedSingleTest", 72, new List<string> { "ParameterizedSingleTest (True)" }));
+                Tuple("ParameterizedSingleTest", 75, new List<string> { "ParameterizedSingleTest (True)" }),
+                Tuple("SkippedTestCase", 81, new List<string>()),
+                Tuple("TestWithDataPointProperty", 86, new List<string>())
+            );
     }
 }

--- a/testadapter/src/execution/TestEventReportListener.cs
+++ b/testadapter/src/execution/TestEventReportListener.cs
@@ -63,7 +63,7 @@ internal sealed class TestEventReportListener : ITestEventListener
 
                 Framework.RecordStart(testCase);
                 if (DetailedOutput)
-                    Framework.SendMessage(TestMessageLevel.Informational, $"TestCase: {testCase.FullyQualifiedName} Processing...");
+                    Framework.SendMessage(TestMessageLevel.Informational, $"TestCase: {testEvent.FullyQualifiedName} Processing...");
                 break;
             }
 
@@ -86,11 +86,14 @@ internal sealed class TestEventReportListener : ITestEventListener
                     EndTime = DateTimeOffset.Now,
                     Duration = testEvent.ElapsedInMs
                 };
+                // Set dynamic driven test name (DataPointAttribute)
+                if (testEvent.DisplayName != null)
+                    testResult.DisplayName = testEvent.DisplayName;
 
                 testEvent.Reports.ForEach(report => AddTestReport(report, testResult));
 
                 if (DetailedOutput)
-                    Framework.SendMessage(TestMessageLevel.Informational, $"TestCase: {testCase.FullyQualifiedName} {testResult.Outcome}");
+                    Framework.SendMessage(TestMessageLevel.Informational, $"TestCase: {testEvent.FullyQualifiedName} {testResult.Outcome}");
                 Framework.RecordResult(testResult);
                 Framework.RecordEnd(testCase, testResult.Outcome);
                 CompletedTests += 1;


### PR DESCRIPTION
# Why
The display name for tests using DataPoint attribute is misleading and not presents the name + test values

# What
Added the optional display name, set only by data driven tests. The display name will be applied on test record if is set.

![image](https://github.com/user-attachments/assets/9ee5863b-9293-4fdd-9f45-838ce61c5ce3)
