### PR TITLE
GD-152: Part8: Fix test runner installation

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           lfs: true
 
-       # the vstest filter is actual not implemented and the argument 'paths' on gdUnit4-action@v1.0.8 will have no affect
+      # the vstest filter is actual not implemented and the argument 'paths' on gdUnit4-action@v1.0.8 will have no affect
       - name: 'Temp solution, we delete the failing test for now.'
         shell: bash
         run: |
@@ -176,9 +176,8 @@ jobs:
           }
 
           validate_section '<Output>' 'Discover tests done, 2 TestSuites and total 15 Tests found.'
-          validate_section '<Output>' 'Start executing tests, 15 TestCases total.'
           validate_section '<Results>' "<Message>Expecting: 'True' but is 'False'</Message>"
           validate_section '<Results>' '<StackTrace>   at Examples.ExampleTest.Failed() in /home/runner/work/gdUnit4Net/gdUnit4Net/example/test/ExampleTest.cs:line 18'
           validate_section '<ResultSummary' '<ResultSummary outcome="Failed">'
-          validate_section '<ResultSummary' '<Counters total="15" executed="15" passed="14" failed="1" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />'
+          validate_section '<ResultSummary' '<Counters total="19" executed="19" passed="18" failed="1" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />'
           echo "All tests passes."

--- a/PackageVersions.props
+++ b/PackageVersions.props
@@ -6,7 +6,7 @@
     <MicrosoftCodeAnalysisCSharpVersion>4.9.2</MicrosoftCodeAnalysisCSharpVersion>
     <MoqVersion>4.18.4</MoqVersion>
     <GdUnitAnalyzersVersion>1.0.0-rc5</GdUnitAnalyzersVersion>
-    <GdUnitAPIVersion>4.4.0-rc7</GdUnitAPIVersion>
+    <GdUnitAPIVersion>4.4.0-rc8</GdUnitAPIVersion>
     <GdUnitTestAdapterVersion>2.1.0-rc3</GdUnitTestAdapterVersion>
   </PropertyGroup>
 </Project>

--- a/api/src/core/runners/GdUnit4TestRunnerSceneCore.cs
+++ b/api/src/core/runners/GdUnit4TestRunnerSceneCore.cs
@@ -1,0 +1,47 @@
+﻿namespace GdUnit4.Core.Runners;
+
+using System;
+
+using Api;
+
+using Godot;
+
+public partial class GdUnit4TestRunnerSceneCore : SceneTree
+{
+    public override void _Initialize()
+    {
+        try
+        {
+            Root.AddChild(new TestRunner());
+        }
+        catch (Exception e)
+        {
+            GD.PrintErr("Exception", e.Message);
+            Quit(100); // Exit with error code
+        }
+    }
+
+    // ReSharper disable once PartialTypeWithSinglePart
+    private sealed partial class TestRunner : Node
+    {
+        public TestRunner()
+        {
+            Logger = new GodotLogger();
+            Server = new GodotGdUnit4RestServer(Logger);
+        }
+
+        private ITestEngineLogger Logger { get; }
+
+        private GodotGdUnit4RestServer Server { get; }
+
+        public override void _Ready() => _ = Server.Start();
+
+        public override void _Process(double delta) => _ = Server.Process();
+
+        public override void _Notification(int what)
+        {
+            if (what == NotificationPredelete)
+                Server.Stop();
+        }
+    }
+}

--- a/api/src/core/runners/GdUnit4TestRunnerSceneTemplate.cs
+++ b/api/src/core/runners/GdUnit4TestRunnerSceneTemplate.cs
@@ -4,50 +4,8 @@
 
 namespace GdUnit4.TestRunner;
 
-using System;
-
-using Api;
-
 using Core.Runners;
 
-using Godot;
-
-public partial class GdUnit4TestRunnerSceneTemplate : SceneTree
+public partial class GdUnit4TestRunnerSceneTemplate : GdUnit4TestRunnerSceneCore
 {
-    public override void _Initialize()
-    {
-        try
-        {
-            Root.AddChild(new TestRunner());
-        }
-        catch (Exception e)
-        {
-            GD.PrintErr("Exception", e.Message);
-            Quit(100); // Exit with error code
-        }
-    }
-
-    // ReSharper disable once PartialTypeWithSinglePart
-    private sealed partial class TestRunner : Node
-    {
-        public TestRunner()
-        {
-            Logger = new GodotLogger();
-            Server = new GodotGdUnit4RestServer(Logger);
-        }
-
-        private ITestEngineLogger Logger { get; }
-
-        private GodotGdUnit4RestServer Server { get; }
-
-        public override void _Ready() => _ = Server.Start();
-
-        public override void _Process(double delta) => _ = Server.Process();
-
-        public override void _Notification(int what)
-        {
-            if (what == NotificationPredelete)
-                Server.Stop();
-        }
-    }
 }

--- a/api/src/core/runners/GodotRuntimeTestRunner.cs
+++ b/api/src/core/runners/GodotRuntimeTestRunner.cs
@@ -183,6 +183,7 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
             return true;
 
         Logger.LogInfo("======== Installing GdUnit4 Godot Runtime Test Runner ========");
+        Logger.LogInfo($"Installing GdUnit4TestRunnerScene at {destinationFolderPath}");
 
         var assembly = Assembly.GetExecutingAssembly();
         using var stream = assembly.GetManifestResourceStream("GdUnit4.src.core.runners.GdUnit4TestRunnerSceneTemplate.cs");
@@ -205,6 +206,7 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
                 WorkingDirectory = workingDirectory
             };
 
+            Logger.LogInfo($"Working dir {workingDirectory}");
             Logger.LogInfo($"Run Rebuild Godot Project ... {GodotBin} {processStartInfo.Arguments}");
             using var compileProcess = new Process();
             compileProcess.StartInfo = processStartInfo;

--- a/example/exampleProject.csproj
+++ b/example/exampleProject.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Godot.NET.Sdk">
   <Import Project="../PackageVersions.props"/>
-
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>11.0</LangVersion>
@@ -9,22 +8,18 @@
     <NullableReferenceTypes>true</NullableReferenceTypes>
     <RootNamespace>Examples</RootNamespace>
   </PropertyGroup>
-
   <PropertyGroup>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!--Disable warning/error of invalid/incompatible GodotSharp version, the package GdUnit4.API is build by V4.2.0-->
     <NoWarn>NU1605</NoWarn>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftSdkVersion)"/>
-    <PackageReference Include="gdUnit4.api" Version="4.4.0-rc*"/>
-    <PackageReference Include="gdUnit4.test.adapter" Version="2.1.0-rc*"/>
-    <!-- comming next
-    <PackageReference Include="gdUnit4.analyzers" Version="1.0.0">
+    <PackageReference Include="gdUnit4.api" Version="4.4.0-rc8"/>
+    <PackageReference Include="gdUnit4.test.adapter" Version="2.1.0-rc3"/>
+    <PackageReference Include="gdUnit4.analyzers" Version="1.0.0-rc5">
       <PrivateAssets>none</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    -->
   </ItemGroup>
 </Project>

--- a/example/nuget.config
+++ b/example/nuget.config
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+
   <!-- This configuration is only for local testing
-  <packageSources>
-    <clear />
-    <add key="gdUnit4.api" value="./../api/nupkg" />
-    <add key="gdUnit4.test.adapter" value="./../testadapter/nupkg" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-  </packageSources>
-  <disabledPackageSources>
-    <add key="nuget.org" value="true" />
-  </disabledPackageSources>
+    <packageSources>
+      <clear/>
+      <add key="gdUnit4.api" value="./../api/nupkg"/>
+      <add key="gdUnit4.test.adapter" value="./../testadapter/nupkg"/>
+      <add key="gdUnit4.analyzers" value="./../analyzers/nupkg"/>
+    </packageSources>
+    <disabledPackageSources>
+      <add key="nuget.org" value="true"/>
+    </disabledPackageSources>
   -->
 </configuration>

--- a/example/test/api/AssertionsTest.cs
+++ b/example/test/api/AssertionsTest.cs
@@ -1,23 +1,29 @@
-
 namespace Example.Tests.API.Asserts;
 
-using Godot;
+using System.Collections;
+
 using GdUnit4;
 using GdUnit4.Asserts;
 
+using Godot;
+using Godot.Collections;
+
 using static GdUnit4.Assertions;
+
+using Array = Array;
+using Vector2 = System.Numerics.Vector2;
 
 [TestSuite]
 public class AssertionsTest
 {
-
     [TestCase]
     public void DoAssertNotYetImplemented()
         => AssertThrown(() => AssertNotYetImplemented())
-            .HasFileLineNumber(16)
+            .HasFileLineNumber(21)
             .HasMessage("Test not yet implemented!");
 
     [TestCase]
+    [RequireGodotRuntime]
     public void AssertThatVariants()
     {
         // Godot number Variants
@@ -32,11 +38,11 @@ public class AssertionsTest
     public void AssertThatOnDynamics()
     {
         // object asserts
-        AssertThat(System.Numerics.Vector2.One).IsEqual(System.Numerics.Vector2.One);
+        AssertThat(Vector2.One).IsEqual(Vector2.One);
         AssertThat(TimeSpan.FromMilliseconds(124)).IsEqual(TimeSpan.FromMilliseconds(124));
 
         // dictionary asserts
-        AssertThat(new System.Collections.Hashtable()).HasSize(0);
+        AssertThat(new Hashtable()).HasSize(0);
 
         // enumerable asserts
         AssertThat(new List<int>()).HasSize(0);
@@ -53,8 +59,8 @@ public class AssertionsTest
         AssertObject(AssertThat((uint)1)).IsInstanceOf<INumberAssert<uint>>();
         AssertObject(AssertThat((long)-1)).IsInstanceOf<INumberAssert<long>>();
         AssertObject(AssertThat((ulong)1)).IsInstanceOf<INumberAssert<ulong>>();
-        AssertObject(AssertThat((float)1.1f)).IsInstanceOf<INumberAssert<float>>();
-        AssertObject(AssertThat((double)1.1d)).IsInstanceOf<INumberAssert<double>>();
+        AssertObject(AssertThat(1.1f)).IsInstanceOf<INumberAssert<float>>();
+        AssertObject(AssertThat(1.1d)).IsInstanceOf<INumberAssert<double>>();
         AssertObject(AssertThat(1.1m)).IsInstanceOf<INumberAssert<decimal>>();
 
         AssertObject(AssertThat(sbyte.MaxValue)).IsInstanceOf<INumberAssert<sbyte>>();
@@ -86,28 +92,31 @@ public class AssertionsTest
     }
 
     [TestCase]
+    [RequireGodotRuntime]
     public void AssertThatEnumerable()
     {
         AssertObject(AssertThat(Array.Empty<byte>())).IsInstanceOf<IEnumerableAssert<byte>>();
-        AssertObject(AssertThat(new System.Collections.ArrayList())).IsInstanceOf<IEnumerableAssert<object>>();
-        AssertObject(AssertThat(new System.Collections.BitArray(new bool[] { true, false }))).IsInstanceOf<IEnumerableAssert<bool>>();
+        AssertObject(AssertThat(new ArrayList())).IsInstanceOf<IEnumerableAssert<object>>();
+        AssertObject(AssertThat(new BitArray(new[] { true, false }))).IsInstanceOf<IEnumerableAssert<bool>>();
         AssertObject(AssertThat(new HashSet<byte>())).IsInstanceOf<IEnumerableAssert<byte>>();
         AssertObject(AssertThat(new List<byte>())).IsInstanceOf<IEnumerableAssert<byte>>();
         AssertObject(AssertThat(new Godot.Collections.Array())).IsInstanceOf<IEnumerableAssert<Variant>>();
-        AssertObject(AssertThat(new Godot.Collections.Array<int>())).IsInstanceOf<IEnumerableAssert<int>>();
+        AssertObject(AssertThat(new Array<int>())).IsInstanceOf<IEnumerableAssert<int>>();
     }
 
     [TestCase]
+    [RequireGodotRuntime]
     public void AssertThatDictionary()
     {
-        AssertObject(AssertThat(new Godot.Collections.Dictionary())).IsInstanceOf<IDictionaryAssert<Variant, Variant>>();
-        AssertObject(AssertThat(new Godot.Collections.Dictionary<string, Variant>())).IsInstanceOf<IDictionaryAssert<string, Variant>>();
-        AssertObject(AssertThat(new Godot.Collections.Dictionary<string, string>())).IsInstanceOf<IDictionaryAssert<string, string>>();
-        AssertObject(AssertThat(new System.Collections.Hashtable())).IsInstanceOf<IDictionaryAssert<object, object>>();
-        AssertObject(AssertThat(new Dictionary<string, object>())).IsInstanceOf<IDictionaryAssert<string, object>>();
+        AssertObject(AssertThat(new Dictionary())).IsInstanceOf<IDictionaryAssert<Variant, Variant>>();
+        AssertObject(AssertThat(new Dictionary<string, Variant>())).IsInstanceOf<IDictionaryAssert<string, Variant>>();
+        AssertObject(AssertThat(new Dictionary<string, string>())).IsInstanceOf<IDictionaryAssert<string, string>>();
+        AssertObject(AssertThat(new Hashtable())).IsInstanceOf<IDictionaryAssert<object, object>>();
+        AssertObject(AssertThat(new System.Collections.Generic.Dictionary<string, object>())).IsInstanceOf<IDictionaryAssert<string, object>>();
     }
 
     [TestCase]
+    [RequireGodotRuntime]
     public void AutoFreeOnNull()
     {
         var obj = AutoFree((Node)null!);


### PR DESCRIPTION
# Why
The installed test runner had no access to private classes like `GodotGdUnit4RestServer` and the run fails with an exception.

# What
- Simplified the test runner to inherit from the test runner core where has internal access to avoid such errors
- set api to rc8
- update example project and fix test failure marked by the analyzer