### PR TITLE
Fixes Godot exception monitoring issues

### DIFF
--- a/PackageVersions.props
+++ b/PackageVersions.props
@@ -6,7 +6,7 @@
     <MicrosoftCodeAnalysisCSharpVersion>4.9.2</MicrosoftCodeAnalysisCSharpVersion>
     <MoqVersion>4.18.4</MoqVersion>
     <GdUnitAnalyzersVersion>1.0.0-rc5</GdUnitAnalyzersVersion>
-    <GdUnitAPIVersion>4.4.0-rc8</GdUnitAPIVersion>
+    <GdUnitAPIVersion>4.4.0-rc9</GdUnitAPIVersion>
     <GdUnitTestAdapterVersion>2.1.0-rc3</GdUnitTestAdapterVersion>
   </PropertyGroup>
 </Project>

--- a/api/src/core/execution/ExecutionContext.cs
+++ b/api/src/core/execution/ExecutionContext.cs
@@ -196,9 +196,9 @@ internal sealed class ExecutionContext : IDisposable
         Stopwatch.Stop();
     }
 
-    public bool IsExpectingToFailWithException(Exception? exception)
+    public bool IsExpectingToFailWithException(Exception? exception, MethodInfo? mi)
     {
-        var attribute = CurrentTestCase?.MethodInfo.GetCustomAttribute<ThrowsExceptionAttribute>();
+        var attribute = mi?.GetCustomAttribute<ThrowsExceptionAttribute>();
         if (attribute == null)
             return false;
 

--- a/api/src/core/execution/TestSuiteExecutionStage.cs
+++ b/api/src/core/execution/TestSuiteExecutionStage.cs
@@ -83,7 +83,7 @@ internal sealed class TestSuiteExecutionStage : IExecutionStage
                 }
                 catch (AsyncDataPointCanceledException e)
                 {
-                    if (!executionContext.IsExpectingToFailWithException(e))
+                    if (!executionContext.IsExpectingToFailWithException(e, testCase.MethodInfo))
                         executionContext.ReportCollector.Consume(
                             new TestReport(
                                 Interrupted,

--- a/api/src/core/execution/monitoring/GodotExceptionMonitor.cs
+++ b/api/src/core/execution/monitoring/GodotExceptionMonitor.cs
@@ -134,7 +134,7 @@ public class GodotExceptionMonitor
     private static bool IsSceneProcessingMethod(string methodName, Type declaringType)
     {
         // Check for common Godot processing methods
-        if (methodName is "_Process" or "_PhysicsProcess" or "_Input" or "_UnhandledInput" or "_Ready")
+        if (methodName is "_Process" or "_PhysicsProcess" or "_Input" or "_UnhandledInput" or "_Ready" or "InvokeGodotClassMethod")
             // Check if the declaring type is or inherits from Node
             return typeof(Node).IsAssignableFrom(declaringType) || typeof(RefCounted).IsAssignableFrom(declaringType);
         return false;

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,4 +1,0 @@
-root = true
-
-[*]
-charset = utf-8

--- a/test/src/core/execution/monitoring/ExampleEventBus.cs
+++ b/test/src/core/execution/monitoring/ExampleEventBus.cs
@@ -1,0 +1,13 @@
+﻿namespace GdUnit4.Tests.Core.Execution.Monitoring;
+
+using Godot;
+
+public partial class ExampleEventBus : Node
+{
+    [Signal]
+    public delegate void OnMyEventEventHandler();
+
+    public void Emit() => EmitSignal(SignalName.OnMyEvent);
+
+    public void Connect(Callable callback) => Connect(SignalName.OnMyEvent, callback);
+}

--- a/test/src/core/execution/monitoring/ExampleWithWithEventBus.cs
+++ b/test/src/core/execution/monitoring/ExampleWithWithEventBus.cs
@@ -1,0 +1,15 @@
+﻿namespace GdUnit4.Tests.Core.Execution.Monitoring;
+
+using System;
+
+using Godot;
+
+public partial class ExampleWithWithEventBus : Node
+{
+    public void Register(ExampleEventBus bus)
+        => bus.Connect(new Callable(this, nameof(MyCallback)));
+
+#pragma warning disable CA2201
+    private void MyCallback() => throw new NullReferenceException("Nope");
+#pragma warning restore CA2201
+}

--- a/test/src/core/execution/monitoring/GodotExceptionMonitorOnClassLevelTest.cs
+++ b/test/src/core/execution/monitoring/GodotExceptionMonitorOnClassLevelTest.cs
@@ -1,0 +1,75 @@
+﻿namespace GdUnit4.Tests.Core.Execution.Monitoring;
+
+using System;
+using System.Collections.Generic;
+
+using Api;
+
+using GdUnit4.Core.Execution;
+
+using Godot;
+
+using static Assertions;
+
+[TestSuite]
+[RequireGodotRuntime]
+[GodotExceptionMonitor]
+public class GodotExceptionMonitorOnClassLevelTest
+{
+    [Before]
+    public void Before() { }
+
+    [After]
+    public void After() { }
+
+    [BeforeTest]
+    public void BeforeTest() { }
+
+    [AfterTest]
+    public void AfterTest() { }
+
+    [TestCase]
+    public void IsExceptionMonitorIsEnabledOnBeforeStage()
+    {
+        var stage = new BeforeExecutionStage(new TestSuite(typeof(GodotExceptionMonitorOnClassLevelTest), new List<TestCaseNode>()));
+        AssertBool(stage.IsMonitoringOnGodotExceptionsEnabled).IsTrue();
+    }
+
+    [TestCase]
+    public void IsExceptionMonitorIsEnabledOnAfterStage()
+    {
+        var stage = new AfterExecutionStage(new TestSuite(typeof(GodotExceptionMonitorOnClassLevelTest), new List<TestCaseNode>()));
+        AssertBool(stage.IsMonitoringOnGodotExceptionsEnabled).IsTrue();
+    }
+
+    [TestCase]
+    public void IsExceptionMonitorIsEnabledOnBeforeTestStage()
+    {
+        var stage = new BeforeTestExecutionStage(new TestSuite(typeof(GodotExceptionMonitorOnClassLevelTest), new List<TestCaseNode>()));
+        AssertBool(stage.IsMonitoringOnGodotExceptionsEnabled).IsTrue();
+    }
+
+    [TestCase]
+    public void IsExceptionMonitorIsEnabledOnAfterTestStage()
+    {
+        var stage = new AfterTestExecutionStage(new TestSuite(typeof(GodotExceptionMonitorOnClassLevelTest), new List<TestCaseNode>()));
+        AssertBool(stage.IsMonitoringOnGodotExceptionsEnabled).IsTrue();
+    }
+
+    [TestCase]
+    [ThrowsException(typeof(NullReferenceException), "Nope", "src/core/execution/monitoring/ExampleWithWithEventBus.cs", 13)]
+    public void MonitorExceptionOnEmitSignal()
+    {
+        var tree = (SceneTree)Engine.GetMainLoop();
+
+        var eventBus = AutoFree(new ExampleEventBus())!;
+        tree.Root.AddChild(eventBus);
+
+        var myClass = AutoFree(new ExampleWithWithEventBus())!;
+        tree.Root.AddChild(myClass);
+
+        myClass.Register(eventBus);
+        // The emitting of the signal do results into a NullReferenceException
+        eventBus.Emit();
+    }
+}

--- a/test/src/core/execution/monitoring/GodotExceptionMonitorTest.cs
+++ b/test/src/core/execution/monitoring/GodotExceptionMonitorTest.cs
@@ -1,19 +1,58 @@
 ﻿namespace GdUnit4.Tests.Core.Execution.Monitoring;
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
+using Api;
+
+using GdUnit4.Core.Execution;
 using GdUnit4.Core.Execution.Exceptions;
 
 using Godot;
+
+using static Assertions;
 
 [TestSuite]
 [RequireGodotRuntime]
 public partial class GodotExceptionMonitorTest
 {
     [TestCase]
+    public void IsExceptionMonitorIsEnabledOnBeforeStage()
+    {
+        var stage = new BeforeExecutionStage(new TestSuite(typeof(GodotExceptionMonitorTest), new List<TestCaseNode>()));
+        // no [Before] hock is set
+        AssertBool(stage.IsMonitoringOnGodotExceptionsEnabled).IsFalse();
+    }
+
+    [TestCase]
+    public void IsExceptionMonitorIsEnabledOnAfterStage()
+    {
+        var stage = new AfterExecutionStage(new TestSuite(typeof(GodotExceptionMonitorTest), new List<TestCaseNode>()));
+        // no [After] hock is set
+        AssertBool(stage.IsMonitoringOnGodotExceptionsEnabled).IsFalse();
+    }
+
+    [TestCase]
+    public void IsExceptionMonitorIsEnabledOnBeforeTestStage()
+    {
+        var stage = new BeforeTestExecutionStage(new TestSuite(typeof(GodotExceptionMonitorTest), new List<TestCaseNode>()));
+        // no [BeforeTest] hock is set
+        AssertBool(stage.IsMonitoringOnGodotExceptionsEnabled).IsFalse();
+    }
+
+    [TestCase]
+    public void IsExceptionMonitorIsEnabledOnAfterTestStage()
+    {
+        var stage = new AfterTestExecutionStage(new TestSuite(typeof(GodotExceptionMonitorTest), new List<TestCaseNode>()));
+        // no [AfterTest] hock is set
+        AssertBool(stage.IsMonitoringOnGodotExceptionsEnabled).IsFalse();
+    }
+
+
+    [TestCase]
     [ThrowsException(typeof(InvalidOperationException), "TestNode '_Ready' failed.",
-        "/src/core/execution/monitoring/GodotExceptionMonitorTest.cs", 63)]
+        "/src/core/execution/monitoring/GodotExceptionMonitorTest.cs", 102)]
     public void CatchExceptionOnAddingNodeToSceneTree()
     {
         var sceneTree = (SceneTree)Engine.GetMainLoop();
@@ -51,7 +90,7 @@ public partial class GodotExceptionMonitorTest
 
     [TestCase]
     [ThrowsException(typeof(TestFailedException), "Testing Godot PushError",
-        "src/core/execution/monitoring/GodotExceptionMonitorTest.cs", 55)]
+        "src/core/execution/monitoring/GodotExceptionMonitorTest.cs", 94)]
     public void PushErrorAsTestFailure() => GD.PushError("Testing Godot PushError");
 
 


### PR DESCRIPTION
# Why
Exceptions thrown by an emitted signal was not cougthed. Using `GodotExceptionMonitor` at class level was ignored to enable the monitoring.

# What
- Added `InvokeGodotClassMethod` on `IsSceneProcessingMethod` to detect Godot method calls
- Evaluate the class attribute `GodotExceptionMonitor` to enable the exception monitoring
- Fixes an issue on validate an expected exception by using the correct execution context method info