### PR TITLE
GD-27: Add VSTest filter support with test categories and traits

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Mike Schulze
+Copyright (c) 2025 Mike Schulze
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-
-<h2 align="center">A Unit Testing Framework in C# for Godot</h2>
-<p align="center">This version of GdUnit4.api is based on Godot <strong>v4.2.2.stable.mono.official [15073afe3] (master branch)</p>
+<h2 align="center">The Unit Testing Framework in C# for Godot</h2>
+<p align="center">This version of GdUnit4.api is based on Godot <strong>v4.3.stable.mono.official [77dcf97d8] (master branch)</p>
 </h2>
 
 <h1 align="center">Supported Godot Versions</h2>
@@ -8,6 +7,7 @@
   <img src="https://img.shields.io/badge/Godot-v4.2.0-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.2.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
   <img src="https://img.shields.io/badge/Godot-v4.2.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
+  <img src="https://img.shields.io/badge/Godot-v4.3.0-%23478cbf?logo=godot-engine&logoColor=cyian&color=green">
 </p>
 
 ## What is gdUnit4Net
@@ -17,29 +17,37 @@ This project provides an API and a VS test adapter to run your Godot C# test in 
 ### Main Features
 
 * Writing, executing and debugging tests
-* Configurable template for generating new test-suites when creating test-cases
 * Wide range of assertion methods for verifying the behavior and output of your code
 * Parameterized Tests (Test Cases) for testing functions with multiple sets of inputs and expected outputs
 * Scene runner for simulating different kinds of inputs and actions, such as mouse clicks and keyboard inputs<br>
-  For example, you can simulate mouse clicks and keyboard inputs by calling the appropriate methods on the runner instance. Additionally, you can wait for a specific signal to be emitted by the scene, or you can wait for a specific function to return a certain value.
+  For example, you can simulate mouse clicks and keyboard inputs by calling the appropriate methods on the runner instance. Additionally, you can wait for a specific signal to be
+  emitted by the scene, or you can wait for a specific function to return a certain value.
 * Visual Studio Test Adapter to run and debug your tests
+* Powerful test filtering capabilities to selectively run tests based on various criteria
 
-There are two packages you need to install
+There are three packages available in this project:
 
-* **gdUnit4.api** is the package to enable GdUnit4 to write unit tests in C#.
-* **gdUnit4.test.adapter** is the GdUnit4 Test Adapter, designed to facilitate the integration of GdUnit4 with test frameworks supporting the Visual Studio Test Platform.
+* **[gdUnit4.api](api/README.md)** - The core package to enable writing and running unit tests in C#.
+* **[gdUnit4.test.adapter](testadapter/README.md)** - The test adapter to integrate GdUnit4 with Visual Studio Test Platform.
+* **[gdUnit4.analyzers](analyzers/README.md)** - A Roslyn-based analyzer that provides compile-time validation for GdUnit4 test attributes.
 
-## Using the gdunit4.api
+## gdunit4.api
 
-Checkout the [readme](api/README.md) to install the `gdunit4.api` package.
+Checkout the [gdUnit4.api README](api/README.md) to install and use the core testing framework.
 
-## Install the gdUnit4.test.adapter
+## gdUnit4.test.adapter
 
-Checkout the [readme](testadapter/README.md) to install the `gdunit4.test.adapater` package.
+Checkout the [gdUnit4.test.adapter README](testadapter/README.md) to install and use the test adapter. This adapter now supports
+powerful [test filtering capabilities](testadapter/TestFilterGuide.md) for selectively running tests based on specific criteria.
+
+## gdUnit4.analyzers
+
+For compile-time validation of your test code, check out the [gdUnit4.analyzers README](analyzers/README.md).
 
 ### Example Project
 
-This [example project](https://github.com/MikeSchulze/gdUnit4Net/tree/master/example) gives you a short insight into how to set up a Godot project to use the GdUnit4 API and test adapter.
+This [example project](https://github.com/MikeSchulze/gdUnit4Net/tree/master/example) gives you a short insight into how to set up a Godot project to use the GdUnit4 API and test
+adapter.
 It contains a single test suite as an example with two tests, the first test will succeed and the second test will fail.
 
 ```c#
@@ -80,6 +88,10 @@ The test run looks like this.
   <a href="https://mikeschulze.github.io/gdUnit4/">API Documentation</a>
 </p>
 
+<p align="left" style="font-family: Bedrock; font-size:21pt; color:#7253ed; font-style:bold">
+  <a href="testadapter/TestFilterGuide.md">Test Filtering Guide</a>
+</p>
+
 ### You Are Welcome To
 
 * [Give Feedback](https://github.com/MikeSchulze/gdUnit4Net/discussions)
@@ -92,11 +104,14 @@ The test run looks like this.
 ### Contribution Guidelines
 
 **Thank you for your interest in contributing to GdUnit4!**<br>
-To ensure a smooth and collaborative contribution process, please review our [contribution guidelines](https://github.com/MikeSchulze/gdUnit4Net/blob/master/api/CONTRIBUTING.md) before getting started. These guidelines outline the standards and expectations we uphold in this project.
+To ensure a smooth and collaborative contribution process, please review our [contribution guidelines](https://github.com/MikeSchulze/gdUnit4Net/blob/master/CONTRIBUTING.md) before
+getting started. These guidelines outline the standards and expectations we uphold in this project.
 
-Code of Conduct: We strictly adhere to the Godot code of conduct in this project. As a contributor, it is important to respect and follow this code to maintain a positive and inclusive community.
+Code of Conduct: We strictly adhere to the Godot code of conduct in this project. As a contributor, it is important to respect and follow this code to maintain a positive and
+inclusive community.
 
-Using GitHub Issues: We utilize GitHub issues for tracking feature requests and bug reports. If you have a general question or wish to engage in discussions, we recommend joining the [GdUnit Discord Server](https://discord.gg/rdq36JwuaJ) for specific inquiries.
+Using GitHub Issues: We utilize GitHub issues for tracking feature requests and bug reports. If you have a general question or wish to engage in discussions, we recommend joining
+the [GdUnit Discord Server](https://discord.gg/rdq36JwuaJ) for specific inquiries.
 
 We value your input and appreciate your contributions to make GdUnit4 even better!
 
@@ -106,11 +121,12 @@ We value your input and appreciate your contributions to make GdUnit4 even bette
 
 ### Thank you for supporting my project
 
-
 ## Sponsors
 
 [<img src="https://avatars.githubusercontent.com/u/4674635?v=4)" alt="Jeff" width="125"/>](https://github.com/jlb0170) Jeff
 
 ---
 
-## Sponsors
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/analyzers/README.md
+++ b/analyzers/README.md
@@ -10,34 +10,37 @@ test attributes and helps developers catch configuration errors early in the dev
 The analyzer must be included by referencing the gdUnit4.analyzer package:
 
 ```xml
-    <PackageReference Include="gdUnit4.api" Version="4.4.0"/>
-    <PackageReference Include="gdUnit4.test.adapter" Version="2.1.0"/>
-    <PackageReference Include="gdUnit4.analyzers" Version="1.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+<PackageReference Include="gdUnit4.api" Version="4.4.0"/>
+<PackageReference Include="gdUnit4.test.adapter" Version="2.1.0"/>
+<PackageReference Include="gdUnit4.analyzers" Version="1.0.0">
+  <PrivateAssets>all</PrivateAssets>
+  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+</PackageReference>
 ```
 
-* Attribute Validation
-
-  The analyzer enforces correct usage of GdUnit4 test attributes:
+* **Attribute Validation:** The analyzer enforces correct usage of GdUnit4 test attributes
 
   #### Example: DataPoint and TestCase Combination Validation
 
   Validates proper combination of DataPoint and TestCase attributes:
 
-    ```csharp
-    // ✅ Valid: Single TestCase with DataPoint
-    [TestCase]
-    [DataPoint(nameof(TestData))]
-    public void ValidTest(int a, int b) { }
-    
-    // ❌ Invalid: Multiple TestCase with DataPoint
-    [TestCase]
-    [TestCase]                         // GdUnit0201 error: Method 'InvalidTest' cannot have multiple TestCase attributes when DataPoint attribute is present
-    [DataPoint(nameof(TestData))]
-    public void InvalidTest(int a, int b) { }
-    ```
+  ```csharp
+  // ✅ Valid: Single TestCase with DataPoint
+  [TestCase]
+  [DataPoint(nameof(TestData))]
+  public void ValidTest(int a, int b) { }
+  
+  // ❌ Invalid: Multiple TestCase with DataPoint
+  [TestCase]
+  [TestCase]                         // GdUnit0201 error: Method 'InvalidTest' cannot have multiple TestCase attributes when DataPoint attribute is present
+  [DataPoint(nameof(TestData))]
+  public void InvalidTest(int a, int b) { }
+  ```
+
+## Related Packages
+
+* [gdUnit4.api](../api/README.md) - The core testing framework
+* [gdUnit4.test.adapter](../testadapter/README.md) - Run your tests in Visual Studio, VS Code, and JetBrains Rider with filtering support
 
 ## Technical Details
 
@@ -47,8 +50,16 @@ The analyzer is built using:
 * Roslyn Analyzer Framework
 * Microsoft.CodeAnalysis.CSharp
 
+## Documentation
+
+For more detailed documentation about the entire GdUnit4 ecosystem, visit our [documentation site](https://mikeschulze.github.io/gdUnit4/).
+
 ### You are welcome to
 
 * [Give Feedback](https://github.com/MikeSchulze/gdUnit4Net/discussions)
 * [Suggest Improvements](https://github.com/MikeSchulze/gdUnit4Net/issues/new?assignees=MikeSchulze&labels=enhancement&template=feature_request.md&title=)
 * [Report Bugs](https://github.com/MikeSchulze/gdUnit4Net/issues/new?assignees=MikeSchulze&labels=bug%2C+task&template=bug_report.md&title=)
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](../LICENSE) file for details.

--- a/api/README.md
+++ b/api/README.md
@@ -20,13 +20,24 @@ gdUnit4.api is the C# package to enable GdUnit4 to run/write unit tests in C#.
 * **Scene runner:** for simulating different kinds of inputs and actions, such as mouse clicks and keyboard inputs<br>
   For example, you can simulate mouse clicks and keyboard inputs by calling the appropriate methods on the runner instance. Additionally, you can wait for a specific signal to be
   emitted by the scene, or you can wait for a specific function to return a certain value.
-* **GdUnit4.Analyzer:** is a Roslyn-based analyzer package designed to enhance the development experience when writing tests with GdUnit4. It provides compile-time validation for
-  GdUnit4
-  test attributes and helps developers catch configuration errors early in the development process.
+* **Integration with Test Adapter:** Works seamlessly with the [gdUnit4.test.adapter](../testadapter/README.md) for running tests in Visual Studio, VS Code, and JetBrains Rider
+
+## Installation
+
+You can install the GdUnit4 API by adding it as a package reference to your project:
+
+```xml
+<PackageReference Include="gdUnit4.api" Version="4.4.0"/>
+```
+
+## Related Packages
+
+* [gdUnit4.test.adapter](../testadapter/README.md) - Run your tests in Visual Studio, VS Code, and JetBrains Rider
+* [gdUnit4.analyzers](../analyzers/README.md) - Add compile-time validation for your test code
 
 ## Short Example
 
-```
+```csharp
 namespace GdUnit4.Tests
 {
     using static Assertions;
@@ -43,6 +54,10 @@ namespace GdUnit4.Tests
  }
 ```
 
+## Documentation
+
+For more information, check out the [complete API documentation](https://mikeschulze.github.io/gdUnit4/).
+
 ---
 
 ### You are welcome to
@@ -55,4 +70,6 @@ namespace GdUnit4.Tests
 
 ---
 
-## Sponsors
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](../LICENSE) file for details.

--- a/api/src/core/attributes/TestCategoryAttribute.cs
+++ b/api/src/core/attributes/TestCategoryAttribute.cs
@@ -1,0 +1,21 @@
+﻿namespace GdUnit4.Core.Attributes;
+
+using System;
+
+/// <summary>
+///     Specifies a category for a test method or class.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
+public class TestCategoryAttribute : Attribute
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="TestCategoryAttribute" /> class.
+    /// </summary>
+    /// <param name="category">The name of the category.</param>
+    public TestCategoryAttribute(string category) => Category = category;
+
+    /// <summary>
+    ///     Gets the name of the category.
+    /// </summary>
+    public string Category { get; }
+}

--- a/api/src/core/attributes/TraitAttribute.cs
+++ b/api/src/core/attributes/TraitAttribute.cs
@@ -1,0 +1,31 @@
+﻿namespace GdUnit4.core.attributes;
+
+using System;
+
+/// <summary>
+///     Specifies a trait for a test method.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
+public class TraitAttribute : Attribute
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="TraitAttribute" /> class.
+    /// </summary>
+    /// <param name="name">The name of the trait.</param>
+    /// <param name="value">The value of the trait.</param>
+    public TraitAttribute(string name, string value)
+    {
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+        Value = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>
+    ///     Gets the name of the trait.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    ///     Gets the value of the trait.
+    /// </summary>
+    public string Value { get; }
+}

--- a/api/src/core/discovery/TestCaseDescriptor.cs
+++ b/api/src/core/discovery/TestCaseDescriptor.cs
@@ -1,6 +1,8 @@
 ﻿namespace GdUnit4.Core.Discovery;
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 using Execution;
 
@@ -61,20 +63,37 @@ public sealed class TestCaseDescriptor : IEquatable<TestCaseDescriptor>
     /// </summary>
     public required bool RequireRunningGodotEngine { get; init; }
 
+    /// <summary>
+    ///     Gets or sets the list of categories associated with this test case.
+    ///     Categories are set by the TestCategory attributes.
+    /// </summary>
+    public List<string> Categories { get; init; } = new();
+
+    /// <summary>
+    ///     Gets or sets the collection of traits associated with this test case.
+    ///     Each trait is a name-value pair that can be used for filtering and reporting.
+    /// </summary>
+    public Dictionary<string, List<string>> Traits { get; init; } = new();
+
+    // ReSharper disable once UsageOfDefaultStructEquality
     public bool Equals(TestCaseDescriptor? other)
     {
         if (other is null) return false;
         if (ReferenceEquals(this, other)) return true;
 
-        return SimpleName == other.SimpleName &&
-               FullyQualifiedName == other.FullyQualifiedName &&
-               AssemblyPath == other.AssemblyPath &&
-               ManagedType == other.ManagedType &&
-               ManagedMethod == other.ManagedMethod &&
-               Id == other.Id &&
-               LineNumber == other.LineNumber &&
-               AttributeIndex == other.AttributeIndex &&
-               RequireRunningGodotEngine == other.RequireRunningGodotEngine;
+        return SimpleName == other.SimpleName
+               && FullyQualifiedName == other.FullyQualifiedName
+               && AssemblyPath == other.AssemblyPath
+               && ManagedType == other.ManagedType
+               && ManagedMethod == other.ManagedMethod
+               && Id == other.Id
+               && LineNumber == other.LineNumber
+               && AttributeIndex == other.AttributeIndex
+               && RequireRunningGodotEngine == other.RequireRunningGodotEngine
+               && Categories.SequenceEqual(other.Categories)
+               && Traits.Count == other.Traits.Count
+               && Traits.Keys.All(key =>
+                   other.Traits.ContainsKey(key) && Traits[key].SequenceEqual(other.Traits[key]));
     }
 
     public TestCaseDescriptor Build(TestCaseAttribute testCaseAttribute, bool hasMultipleAttributes)
@@ -103,6 +122,8 @@ public sealed class TestCaseDescriptor : IEquatable<TestCaseDescriptor>
         hashCode.Add(LineNumber);
         hashCode.Add(AttributeIndex);
         hashCode.Add(RequireRunningGodotEngine);
+        hashCode.Add(Categories.Count);
+        hashCode.Add(Traits.Count);
         return hashCode.ToHashCode();
     }
 

--- a/example/exampleProject.csproj
+++ b/example/exampleProject.csproj
@@ -15,12 +15,13 @@
     <!-- Prevent MSTest adapter from being discovered -->
     <VSTestTestAdapterPath>none</VSTestTestAdapterPath>
     <TestFramework>GdUnit4</TestFramework>
+
+
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftSdkVersion)"/>
-    <!-- Add the MSTest adapter but set it to private to prevent conflicts -->
+    <!-- We only include here the MSTest framework to run tests mixed with MSTest assertions, but set it to private to prevent conflicts -->
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" ExcludeAssets="build;analyzers;native"/>
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" PrivateAssets="all"/>
     <PackageReference Include="gdUnit4.api" Version="4.4.0-rc12"/>
     <PackageReference Include="gdUnit4.test.adapter" Version="2.1.0-rc4"/>
     <PackageReference Include="gdUnit4.analyzers" Version="1.0.0-rc5">

--- a/test/gdUnit4Test.csproj
+++ b/test/gdUnit4Test.csproj
@@ -24,10 +24,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftSdkVersion)"/>
-    <!-- We only include here the MSTest framework to run tests mixed with MSTest assertions-->
+    <!-- We only include here the MSTest framework to run tests mixed with MSTest assertions, but set it to private to prevent conflicts -->
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" ExcludeAssets="build;analyzers;native"/>
-    <!-- Add the MSTest adapter but set it to private to prevent conflicts -->
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" PrivateAssets="all"/>
     <ProjectReference Include="..\api\gdUnit4Api.csproj"/>
     <ProjectReference Include="..\testadapter\gdUnit4TestAdapter.csproj"/>
     <PackageReference Include="gdUnit4.analyzers" Version="$(GdUnitAnalyzersVersion)">

--- a/test/src/core/ExampleTestSuite.cs
+++ b/test/src/core/ExampleTestSuite.cs
@@ -4,6 +4,9 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
+using GdUnit4.core.attributes;
+using GdUnit4.Core.Attributes;
+
 using static Assertions;
 
 using static Utils;
@@ -36,6 +39,8 @@ public sealed class ExampleTestSuite
     }
 
     [TestCase]
+    [TestCategory("CategoryA")]
+    [Trait("Category", "Foo")]
     public void TestFoo()
     {
 #pragma warning disable IDE0022 // Use expression body for method

--- a/test/src/core/discovery/TestCaseDescriptorTest.cs
+++ b/test/src/core/discovery/TestCaseDescriptorTest.cs
@@ -1,0 +1,59 @@
+﻿namespace GdUnit4.Tests.Core.Discovery;
+
+using System;
+using System.Collections.Generic;
+
+using GdUnit4.Core.Discovery;
+
+using static Assertions;
+
+[TestSuite]
+public class TestCaseDescriptorTest
+{
+    [TestCase]
+    public void IsEqual()
+    {
+        var guid = Guid.NewGuid();
+        var dsA = new TestCaseDescriptor
+        {
+            SimpleName = "TestA",
+            FullyQualifiedName = "GdUnit4.Tests.Core.Discovery.ExampleTestSuiteToDiscover.TestA",
+            AssemblyPath = "/path/to/test_assembly.dll",
+            ManagedType = "GdUnit4.Tests.Core.Discovery.ExampleTestSuiteToDiscover",
+            ManagedMethod = "SingleTestCaseWithCustomName",
+            Id = guid,
+            LineNumber = 29,
+            CodeFilePath = "d:/projectX/tests/core/discovery/ExampleTestSuiteToDiscover.cs",
+            AttributeIndex = 0,
+            RequireRunningGodotEngine = false,
+            Categories = new List<string>
+            {
+                "CategoryA",
+                "Foo"
+            },
+            Traits = new Dictionary<string, List<string>> { ["Category"] = new() { "Foo" } }
+        };
+
+        var dsB = new TestCaseDescriptor
+        {
+            SimpleName = "TestA",
+            FullyQualifiedName = "GdUnit4.Tests.Core.Discovery.ExampleTestSuiteToDiscover.TestA",
+            AssemblyPath = "/path/to/test_assembly.dll",
+            ManagedType = "GdUnit4.Tests.Core.Discovery.ExampleTestSuiteToDiscover",
+            ManagedMethod = "SingleTestCaseWithCustomName",
+            Id = guid,
+            LineNumber = 29,
+            CodeFilePath = "d:/projectX/tests/core/discovery/ExampleTestSuiteToDiscover.cs",
+            AttributeIndex = 0,
+            RequireRunningGodotEngine = false,
+            Categories = new List<string>
+            {
+                "CategoryA",
+                "Foo"
+            },
+            Traits = new Dictionary<string, List<string>> { ["Category"] = new() { "Foo" } }
+        };
+
+        AssertBool(dsA.Equals(dsB)).IsTrue();
+    }
+}

--- a/test/src/core/discovery/TestCaseDiscovererTest.cs
+++ b/test/src/core/discovery/TestCaseDiscovererTest.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
+using GdUnit4.core.attributes;
+using GdUnit4.Core.Attributes;
 using GdUnit4.Core.Discovery;
 
 using Godot;
@@ -21,6 +23,9 @@ public sealed class ExampleTestSuiteToDiscover
     }
 
     [TestCase(TestName = "TestA")]
+    [TestCategory("CategoryA")]
+    [Trait("Category", "Foo")]
+    [Trait("Category", "Bar")]
     public void SingleTestCaseWithCustomName()
         => AssertBool(true).IsEqual(true);
 
@@ -67,7 +72,7 @@ public class TestCaseDiscovererTest
             ManagedType = "GdUnit4.Tests.Core.Discovery.ExampleTestSuiteToDiscover",
             ManagedMethod = "SingleTestCase",
             Id = tests[0].Id,
-            LineNumber = 20,
+            LineNumber = 22,
             CodeFilePath = codeFilePath,
             AttributeIndex = 0,
             RequireRunningGodotEngine = false
@@ -80,19 +85,29 @@ public class TestCaseDiscovererTest
         var codeFilePath = DiscoverTestUtils.GetSourceFilePath("src/core/discovery/TestCaseDiscovererTest.cs");
         var tests = DiscoverTests<ExampleTestSuiteToDiscover>(nameof(ExampleTestSuiteToDiscover.SingleTestCaseWithCustomName));
 
-        AssertThat(tests).ContainsExactly(new TestCaseDescriptor
-        {
-            SimpleName = "TestA",
-            FullyQualifiedName = "GdUnit4.Tests.Core.Discovery.ExampleTestSuiteToDiscover.TestA",
-            AssemblyPath = "/path/to/test_assembly.dll",
-            ManagedType = "GdUnit4.Tests.Core.Discovery.ExampleTestSuiteToDiscover",
-            ManagedMethod = "SingleTestCaseWithCustomName",
-            Id = tests[0].Id,
-            LineNumber = 25,
-            CodeFilePath = codeFilePath,
-            AttributeIndex = 0,
-            RequireRunningGodotEngine = false
-        });
+        AssertThat(tests)
+            .ContainsExactly(new TestCaseDescriptor
+            {
+                SimpleName = "TestA",
+                FullyQualifiedName = "GdUnit4.Tests.Core.Discovery.ExampleTestSuiteToDiscover.TestA",
+                AssemblyPath = "/path/to/test_assembly.dll",
+                ManagedType = "GdUnit4.Tests.Core.Discovery.ExampleTestSuiteToDiscover",
+                ManagedMethod = "SingleTestCaseWithCustomName",
+                Id = tests[0].Id,
+                LineNumber = 30,
+                CodeFilePath = codeFilePath,
+                AttributeIndex = 0,
+                RequireRunningGodotEngine = false,
+                Categories = new List<string> { "CategoryA" },
+                Traits = new Dictionary<string, List<string>>
+                {
+                    ["Category"] = new()
+                    {
+                        "Foo",
+                        "Bar"
+                    }
+                }
+            });
     }
 
     [TestCase]
@@ -112,7 +127,7 @@ public class TestCaseDiscovererTest
                     ManagedType = "GdUnit4.Tests.Core.Discovery.ExampleTestSuiteToDiscover",
                     ManagedMethod = "MultiRowTestCase",
                     Id = tests[0].Id,
-                    LineNumber = 31,
+                    LineNumber = 36,
                     CodeFilePath = codeFilePath,
                     AttributeIndex = 0,
                     RequireRunningGodotEngine = false
@@ -125,7 +140,7 @@ public class TestCaseDiscovererTest
                     ManagedType = "GdUnit4.Tests.Core.Discovery.ExampleTestSuiteToDiscover",
                     ManagedMethod = "MultiRowTestCase",
                     Id = tests[1].Id,
-                    LineNumber = 31,
+                    LineNumber = 36,
                     CodeFilePath = codeFilePath,
                     AttributeIndex = 1,
                     RequireRunningGodotEngine = false
@@ -138,7 +153,7 @@ public class TestCaseDiscovererTest
                     ManagedType = "GdUnit4.Tests.Core.Discovery.ExampleTestSuiteToDiscover",
                     ManagedMethod = "MultiRowTestCase",
                     Id = tests[2].Id,
-                    LineNumber = 31,
+                    LineNumber = 36,
                     CodeFilePath = codeFilePath,
                     AttributeIndex = 2,
                     RequireRunningGodotEngine = false
@@ -163,7 +178,7 @@ public class TestCaseDiscovererTest
                     ManagedType = "GdUnit4.Tests.Core.Discovery.ExampleTestSuiteToDiscover",
                     ManagedMethod = "MultiRowTestCaseWithCustomTestName",
                     Id = tests[0].Id,
-                    LineNumber = 38,
+                    LineNumber = 43,
                     CodeFilePath = codeFilePath,
                     AttributeIndex = 0,
                     RequireRunningGodotEngine = false
@@ -176,7 +191,7 @@ public class TestCaseDiscovererTest
                     ManagedType = "GdUnit4.Tests.Core.Discovery.ExampleTestSuiteToDiscover",
                     ManagedMethod = "MultiRowTestCaseWithCustomTestName",
                     Id = tests[1].Id,
-                    LineNumber = 38,
+                    LineNumber = 43,
                     CodeFilePath = codeFilePath,
                     AttributeIndex = 1,
                     RequireRunningGodotEngine = false
@@ -189,7 +204,7 @@ public class TestCaseDiscovererTest
                     ManagedType = "GdUnit4.Tests.Core.Discovery.ExampleTestSuiteToDiscover",
                     ManagedMethod = "MultiRowTestCaseWithCustomTestName",
                     Id = tests[2].Id,
-                    LineNumber = 38,
+                    LineNumber = 43,
                     CodeFilePath = codeFilePath,
                     AttributeIndex = 2,
                     RequireRunningGodotEngine = false
@@ -211,7 +226,7 @@ public class TestCaseDiscovererTest
             ManagedType = "GdUnit4.Tests.Core.Discovery.ExampleTestSuiteToDiscover",
             ManagedMethod = "ThreadedTestCase",
             Id = tests[0].Id,
-            LineNumber = 43,
+            LineNumber = 48,
             CodeFilePath = codeFilePath,
             AttributeIndex = 0,
             RequireRunningGodotEngine = false
@@ -232,7 +247,7 @@ public class TestCaseDiscovererTest
             ManagedType = "GdUnit4.Tests.Core.Discovery.ExampleTestSuiteToDiscover",
             ManagedMethod = "ThreadedTestCaseTyped",
             Id = tests[0].Id,
-            LineNumber = 47,
+            LineNumber = 52,
             CodeFilePath = codeFilePath,
             AttributeIndex = 0,
             RequireRunningGodotEngine = false
@@ -260,10 +275,12 @@ public class TestCaseDiscovererTest
                 ManagedType = "GdUnit4.Tests.Core.ExampleTestSuite",
                 ManagedMethod = "TestFoo",
                 Id = tests[0].Id,
-                LineNumber = 40,
+                LineNumber = 45,
                 CodeFilePath = codeFilePath,
                 AttributeIndex = 0,
-                RequireRunningGodotEngine = false
+                RequireRunningGodotEngine = false,
+                Categories = new List<string> { "CategoryA" },
+                Traits = new Dictionary<string, List<string>> { ["Category"] = new() { "Foo" } }
             }, new TestCaseDescriptor
             {
                 SimpleName = "TestCaseA:0 (1, 2, 3, 6)",
@@ -272,7 +289,7 @@ public class TestCaseDiscovererTest
                 ManagedType = "GdUnit4.Tests.Core.ExampleTestSuite",
                 ManagedMethod = "TestCaseArguments",
                 Id = tests[4].Id,
-                LineNumber = 62,
+                LineNumber = 67,
                 CodeFilePath = codeFilePath,
                 AttributeIndex = 0,
                 RequireRunningGodotEngine = false
@@ -284,7 +301,7 @@ public class TestCaseDiscovererTest
                 ManagedType = "GdUnit4.Tests.Core.ExampleTestSuite",
                 ManagedMethod = "TestCaseArguments",
                 Id = tests[5].Id,
-                LineNumber = 62,
+                LineNumber = 67,
                 CodeFilePath = codeFilePath,
                 AttributeIndex = 1,
                 RequireRunningGodotEngine = false
@@ -301,6 +318,13 @@ public class TestCaseDiscovererTest
         };
         using var assemblyDefinition = AssemblyDefinition.ReadAssembly(clazzType.Module.FullyQualifiedName, readerParameters);
         var methodDefinition = DiscoverTestUtils.FindMethodDefinition(assemblyDefinition, clazzType, testMethod);
-        return TestCaseDiscoverer.DiscoverTestCasesFromMethod(methodDefinition, false, "/path/to/test_assembly.dll", clazzType.FullName!);
+        return TestCaseDiscoverer.DiscoverTestCasesFromMethod(
+            null,
+            methodDefinition,
+            "/path/to/test_assembly.dll",
+            false,
+            clazzType.FullName!,
+            new List<string>(),
+            new Dictionary<string, List<string>>());
     }
 }

--- a/testadapter.test/test/NoOpLogger.cs
+++ b/testadapter.test/test/NoOpLogger.cs
@@ -1,0 +1,10 @@
+﻿namespace GdUnit4.TestAdapter.test;
+
+using Api;
+
+public sealed class NoOpLogger : ITestEngineLogger
+{
+    public void SendMessage(ITestEngineLogger.Level level, string message)
+    {
+    }
+}

--- a/testadapter.test/test/execution/TestCaseFilterTest.cs
+++ b/testadapter.test/test/execution/TestCaseFilterTest.cs
@@ -1,0 +1,361 @@
+﻿namespace GdUnit4.TestAdapter.Test.Execution;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using Api;
+
+using Core.Discovery;
+
+using Extensions;
+
+using Microsoft.VisualStudio.TestPlatform.Common.Filtering;
+using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Adapter;
+using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Discovery;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using test;
+
+using TestAdapter.Execution;
+using TestAdapter.Settings;
+
+[TestClass]
+public class TestCaseFilterTest
+{
+    // ReSharper disable once InconsistentNaming
+    private static TestCase TestNamespace_ExampleTestSuiteA_TestA;
+
+    // ReSharper disable once InconsistentNaming
+    private static TestCase TestNamespace_ExampleTestSuiteA_TestB;
+
+    // ReSharper disable once InconsistentNaming
+    private static TestCase OtherNamespace_ExampleTestSuiteB_TestA;
+
+    // ReSharper disable once InconsistentNaming
+    private static TestCase OtherNamespace_ExampleTestSuiteB_TestB;
+
+    private static List<TestCase> testsExamples;
+
+    private static readonly ITestEngineLogger Logger = new NoOpLogger();
+
+    [ClassInitialize]
+    public static void SetUp(TestContext testContext)
+    {
+        var testDescriptors = new List<TestCaseDescriptor>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                ManagedType = "TestNamespace.ExampleTestSuiteA",
+                ManagedMethod = "TestA",
+                FullyQualifiedName = "TestNamespace.ExampleTestSuiteA.TestA",
+                AssemblyPath = "/debug/examples.dll",
+                AttributeIndex = 0,
+                CodeFilePath = "/tests/core/ExampleTestSuiteA.cs",
+                LineNumber = 12,
+                RequireRunningGodotEngine = false,
+                Categories =
+                {
+                    "UnitTest",
+                    "Fast"
+                },
+                Traits =
+                {
+                    ["Owner"] = new List<string> { "TeamA" },
+                    ["Priority"] = new List<string> { "High" }
+                }
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                ManagedType = "TestNamespace.ExampleTestSuiteA",
+                ManagedMethod = "TestB",
+                FullyQualifiedName = "TestNamespace.ExampleTestSuiteA.TestB",
+                AssemblyPath = "/debug/examples.dll",
+                AttributeIndex = 0,
+                CodeFilePath = "/tests/core/ExampleTestSuiteA.cs",
+                LineNumber = 22,
+                RequireRunningGodotEngine = false,
+                Categories = { "IntegrationTest" },
+                Traits =
+                {
+                    ["Owner"] = new List<string> { "TeamB" },
+                    ["Priority"] = new List<string> { "Medium" },
+                    ["Component"] = new List<string> { "Database" }
+                }
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                ManagedType = "OtherNamespace.ExampleTestSuiteB",
+                ManagedMethod = "TestA",
+                FullyQualifiedName = "OtherNamespace.ExampleTestSuiteB.TestA",
+                AssemblyPath = "/debug/examples.dll",
+                AttributeIndex = 0,
+                CodeFilePath = "/tests/core/ExampleTestSuiteB.cs",
+                LineNumber = 32,
+                RequireRunningGodotEngine = false,
+                Categories = { "SlowTest" },
+                Traits =
+                {
+                    ["Owner"] = new List<string> { "TeamC" },
+                    ["Priority"] = new List<string> { "Low" },
+                    ["Feature"] = new List<string> { "Reporting" }
+                }
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                ManagedType = "OtherNamespace.ExampleTestSuiteB",
+                ManagedMethod = "TestB",
+                FullyQualifiedName = "OtherNamespace.ExampleTestSuiteB.TestB",
+                AssemblyPath = "/debug/examples.dll",
+                AttributeIndex = 0,
+                CodeFilePath = "/tests/core/ExampleTestSuiteB.cs",
+                LineNumber = 45,
+                RequireRunningGodotEngine = false,
+                Categories =
+                {
+                    "UnitTest",
+                    "SlowTest"
+                },
+                Traits =
+                {
+                    ["Owner"] = new List<string>
+                    {
+                        "TeamA",
+                        "TeamC"
+                    }, // Multiple values for a trait
+                    ["Priority"] = new List<string> { "Medium" },
+                    ["Component"] = new List<string> { "UI" }
+                }
+            }
+        };
+        var settings = new GdUnit4Settings { DisplayName = GdUnit4Settings.DisplayNameOptions.FullyQualifiedName };
+
+        testsExamples = testDescriptors
+            .Select(descriptor =>
+            {
+                // Use the actual BuildTestCase method from GdUnit4TestDiscoverer
+                var testCase = GdUnit4TestDiscoverer.BuildTestCase(descriptor, settings);
+                return testCase;
+            })
+            .ToList();
+
+
+        TestNamespace_ExampleTestSuiteA_TestA = testsExamples[0];
+        TestNamespace_ExampleTestSuiteA_TestB = testsExamples[1];
+        OtherNamespace_ExampleTestSuiteB_TestA = testsExamples[2];
+        OtherNamespace_ExampleTestSuiteB_TestB = testsExamples[3];
+    }
+
+    [TestMethod]
+    public void PropertyProvider()
+    {
+        var provider = TestCaseExtensions.GetPropertyProvider();
+
+        Assert.AreEqual(TestCaseExtensions.NamespaceProperty, provider.Invoke("Namespace"));
+        Assert.AreEqual(TestCaseExtensions.ManagedTypeProperty, provider.Invoke("Class"));
+        Assert.AreEqual(TestCaseProperties.DisplayName, provider.Invoke("Name"));
+        Assert.AreEqual(TestCaseProperties.FullyQualifiedName, provider.Invoke("FullyQualifiedName"));
+        Assert.AreEqual(TestCaseExtensions.RequireRunningGodotEngineProperty, provider.Invoke("RequireRunningGodotEngine"));
+        Assert.AreEqual(TestCaseExtensions.TestCategoryProperty, provider.Invoke("TestCategory"));
+    }
+
+    [TestMethod]
+    public void GetPropertyValueTestCategoryAsProperty()
+    {
+        var test = new TestCase("Test1", new Uri(GdUnit4TestExecutor.ExecutorUri), "GdUnit4Net");
+        test.SetPropertyValue(TestCaseExtensions.TestCategoryProperty, new[] { "CategoryA", "CategoryB" });
+        var value = test.GetPropertyValue("TestCategory") as string[];
+
+        CollectionAssert.AreEqual(new[] { "CategoryA", "CategoryB" }, value);
+    }
+
+    [TestMethod]
+    public void FilterNone()
+    {
+        var filteredTests = new TestCaseFilter(new RunContext(), Logger).Execute(testsExamples);
+        Assert.AreEqual(testsExamples.Count, filteredTests.Count);
+        CollectionAssert.AllItemsAreInstancesOfType(filteredTests, typeof(TestCase));
+    }
+
+    [TestMethod]
+    public void FilterByFullyQualifiedName()
+    {
+        // Create a run context with a filter for FullyQualifiedName
+        var runContext = new TestRunContext().WithFilter("FullyQualifiedName=TestNamespace.ExampleTestSuiteA.TestA");
+        var filteredTests = new TestCaseFilter(runContext, Logger).Execute(testsExamples);
+
+        CollectionAssert.AreEquivalent(new[] { TestNamespace_ExampleTestSuiteA_TestA }, filteredTests);
+    }
+
+    [TestMethod]
+    public void FilterByFullyQualifiedNamePattern()
+    {
+        // Create a run context with a filter using ~ (contains) operator
+        var runContext = new TestRunContext().WithFilter("FullyQualifiedName~ExampleTestSuiteA");
+        var filteredTests = new TestCaseFilter(runContext, Logger).Execute(testsExamples);
+
+        CollectionAssert.AreEquivalent(
+            new[] { TestNamespace_ExampleTestSuiteA_TestA, TestNamespace_ExampleTestSuiteA_TestB }, filteredTests);
+    }
+
+    [TestMethod]
+    public void FilterByDisplayName()
+    {
+        var runContext = new TestRunContext().WithFilter("Name=TestA");
+        var filteredTests = new TestCaseFilter(runContext, Logger).Execute(testsExamples);
+
+        Assert.AreEqual(2, filteredTests.Count);
+        Assert.IsTrue(filteredTests.All(t => t.DisplayName == "TestA"));
+    }
+
+    [TestMethod]
+    public void FilterByClass()
+    {
+        var runContext = new TestRunContext().WithFilter("Class=TestNamespace.ExampleTestSuiteA");
+        var filteredTests = new TestCaseFilter(runContext, Logger).Execute(testsExamples);
+
+        CollectionAssert.AreEquivalent(
+            new[] { TestNamespace_ExampleTestSuiteA_TestA, TestNamespace_ExampleTestSuiteA_TestB }, filteredTests);
+    }
+
+    [TestMethod]
+    public void FilterByNamespace()
+    {
+        var runContext = new TestRunContext().WithFilter("Namespace=TestNamespace");
+        var filteredTests = new TestCaseFilter(runContext, Logger).Execute(testsExamples);
+
+        CollectionAssert.AreEquivalent(
+            new[] { TestNamespace_ExampleTestSuiteA_TestA, TestNamespace_ExampleTestSuiteA_TestB }, filteredTests);
+    }
+
+    [TestMethod]
+    public void FilterByTestCategoryAttribute()
+    {
+        var runContext = new TestRunContext().WithFilter("TestCategory=UnitTest");
+        var filteredTests = new TestCaseFilter(runContext, Logger).Execute(testsExamples);
+
+        // verify the correct tests are filtered
+        CollectionAssert.AreEquivalent(
+            new[] { TestNamespace_ExampleTestSuiteA_TestA, OtherNamespace_ExampleTestSuiteB_TestB }, filteredTests);
+    }
+
+    [TestMethod]
+    public void FilterByMultipleCategories()
+    {
+        var runContext = new TestRunContext().WithFilter("TestCategory=UnitTest&TestCategory=Fast");
+        var filteredTests = new TestCaseFilter(runContext, Logger).Execute(testsExamples);
+
+        CollectionAssert.AreEquivalent(new[] { TestNamespace_ExampleTestSuiteA_TestA }, filteredTests);
+    }
+
+    [TestMethod]
+    public void FilterByTraitWithSingleValue()
+    {
+        var runContext = new TestRunContext().WithFilter("Trait.Owner=TeamA");
+        var filteredTests = new TestCaseFilter(runContext, Logger).Execute(testsExamples);
+
+        Assert.AreEqual(2, filteredTests.Count);
+        Assert.IsTrue(filteredTests.All(t =>
+            t.Traits.Any(tr => tr.Name == "Owner" && tr.Value == "TeamA")));
+    }
+
+    [TestMethod]
+    public void FilterByTraitContains()
+    {
+        var runContext = new TestRunContext().WithFilter("Trait.Component~Data");
+        var filteredTests = new TestCaseFilter(runContext, Logger).Execute(testsExamples);
+
+        CollectionAssert.AreEquivalent(new[] { TestNamespace_ExampleTestSuiteA_TestB }, filteredTests);
+    }
+
+    [TestMethod]
+    public void FilterByMultipleTraits()
+    {
+        var runContext = new TestRunContext().WithFilter("Trait.Owner=TeamC&Trait.Priority=Low");
+        var filteredTests = new TestCaseFilter(runContext, Logger).Execute(testsExamples);
+
+        CollectionAssert.AreEquivalent(new[] { OtherNamespace_ExampleTestSuiteB_TestA }, filteredTests);
+    }
+
+    [TestMethod]
+    public void FilterByCombiningCategoryAndTrait()
+    {
+        var runContext = new TestRunContext().WithFilter("TestCategory=UnitTest&Trait.Component=UI");
+        var filteredTests = new TestCaseFilter(runContext, Logger).Execute(testsExamples);
+
+        CollectionAssert.AreEquivalent(new[] { OtherNamespace_ExampleTestSuiteB_TestB }, filteredTests);
+    }
+
+    [TestMethod]
+    public void FilterWithOrOperator()
+    {
+        var runContext = new TestRunContext().WithFilter("TestCategory=UnitTest|TestCategory=SlowTest");
+        var filteredTests = new TestCaseFilter(runContext, Logger).Execute(testsExamples);
+
+        CollectionAssert.AreEquivalent(
+            new[] { TestNamespace_ExampleTestSuiteA_TestA, OtherNamespace_ExampleTestSuiteB_TestA, OtherNamespace_ExampleTestSuiteB_TestB }, filteredTests);
+    }
+
+    [TestMethod]
+    public void FilterWithNotOperator()
+    {
+        var runContext = new TestRunContext().WithFilter("TestCategory!=IntegrationTest");
+        var filteredTests = new TestCaseFilter(runContext, Logger).Execute(testsExamples);
+
+        Assert.AreEqual(3, filteredTests.Count);
+        Assert.IsFalse(filteredTests.Any(t =>
+            t.Traits.Any(trait => trait.Name == "Category" && trait.Value == "IntegrationTest")));
+    }
+
+    [TestMethod]
+    public void FilterWithComplexExpression()
+    {
+        var runContext = new TestRunContext().WithFilter("(Namespace=TestNamespace|Trait.Feature=Reporting)&TestCategory!=IntegrationTest");
+        var filteredTests = new TestCaseFilter(runContext, Logger).Execute(testsExamples);
+
+        CollectionAssert.AreEquivalent(
+            new[] { TestNamespace_ExampleTestSuiteA_TestA, OtherNamespace_ExampleTestSuiteB_TestA }, filteredTests);
+    }
+
+    [TestMethod]
+    public void FilterWithVeryComplexExpressionCombiningMultipleTraits()
+    {
+        var runContext = new TestRunContext().WithFilter(
+            "(TestCategory=UnitTest|Trait.Priority=Low)&(Trait.Owner=TeamA|Trait.Owner=TeamC)&TestCategory!=IntegrationTest");
+        var filteredTests = new TestCaseFilter(runContext, Logger).Execute(testsExamples);
+
+        CollectionAssert.AreEquivalent(
+            new[] { TestNamespace_ExampleTestSuiteA_TestA, OtherNamespace_ExampleTestSuiteB_TestA, OtherNamespace_ExampleTestSuiteB_TestB }, filteredTests);
+    }
+
+    [TestMethod]
+    public void InvalidFilterWithUnbalancedParentheses()
+    {
+        // Unbalanced parentheses in the expression
+        var runContext = new TestRunContext().WithFilter("(TestCategory=UnitTest&(Namespace=TestNamespace");
+        var filteredTests = new TestCaseFilter(runContext, Logger).Execute(testsExamples);
+
+        // Should handle this gracefully rather than throwing exceptions
+        Assert.AreEqual(testsExamples.Count, filteredTests.Count);
+    }
+
+    private sealed class TestRunContext : RunContext
+    {
+        public TestRunContext WithFilter(string filter)
+        {
+            // Set the FilterExpressionWrapper property on the RunContext
+            var property = typeof(DiscoveryContext).GetProperty("FilterExpressionWrapper",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            var filterExpressionWrapper = new FilterExpressionWrapper(filter);
+            property?.SetValue(this, filterExpressionWrapper);
+
+            return this;
+        }
+    }
+}

--- a/testadapter/README.md
+++ b/testadapter/README.md
@@ -1,27 +1,76 @@
-
 # GdUnit4 Test Adapter
 
 This is the GdUnit4 Test Adapter, designed to facilitate the integration of GdUnit4 with test frameworks supporting the Visual Studio Test Platform.
 
-The GdUnit4.testadapter implements the Microsoft test adapter framework. [VSTest](https://github.com/microsoft/vstest?tab=readme-ov-file#vstest).
+The GdUnit4.testadapter implements the Microsoft test adapter framework [VSTest](https://github.com/microsoft/vstest?tab=readme-ov-file#vstest).
+
+## Features
+
+- **Seamless Integration** with Visual Studio, VS Code, and JetBrains Rider
+- **Test Discovery** to find all GdUnit4 tests in your project
+- **Test Execution** to run tests directly from your IDE
+- **Test Debugging** to step through your tests
+- **Error Navigation** to jump directly to test failures
+- **Solution Configuration** with test config files
+- **Powerful Test Filtering** to selectively run tests based on various criteria
 
 ## Supported IDE's
 
-
-|IDE|Test Discovery|Test Run|Test Debug|Jump to Failure|Solution test config file|Test Filter|Parallel Test Execution|
-|---|---|---|---|---|---|---|---|
-|Visual Studio     |✅|✅|✅|✅|✅|🔜|❌|
-|Visual Studio Code|✅|✅|✅|✅|✅|🔜|❌|
-|JetBrains Rider min version 2024.2 |✅|✅|✅|✅|✅|🔜|❌|
+| IDE                                | Test Discovery | Test Run | Test Debug | Jump to Failure | Solution test config file | Test Filter | Parallel Test Execution |
+|------------------------------------|----------------|----------|------------|-----------------|---------------------------|-------------|-------------------------|
+| Visual Studio                      | ✅              | ✅        | ✅          | ✅               | ✅                         | ✅           | ❌                       |
+| Visual Studio Code                 | ✅              | ✅        | ✅          | ✅               | ✅                         | ✅           | ❌                       |
+| JetBrains Rider min version 2024.2 | ✅              | ✅        | ✅          | ✅               | ✅                         | ✅           | ❌                       |
 
 > ✅ - supported<br>
 > ☑️ - supported by a workaround (link)<br>
 > ❌ - not supported<br>
-> 🔜 - not yet implemented<br>
 
-The full documentation can be found [here](https://mikeschulze.github.io/gdUnit4/faq/vstest-adapter/)
+## Installation
 
+Add the Test Adapter to your test project:
 
+```xml
+<PackageReference Include="gdUnit4.test.adapter" Version="2.1.0" />
+```
+
+## Test Filtering
+
+GdUnit4 now supports powerful test filtering capabilities, allowing you to selectively run tests based on various criteria such as test name, class, namespace, category, and custom
+traits.
+
+### Basic Filter Syntax
+
+```
+PropertyName=Value
+```
+
+### Example Filters
+
+```
+# Run only tests in a specific class
+Class=CalculatorTests
+
+# Run tests with a specific category
+TestCategory=UnitTest
+
+# Run tests with specific traits
+Trait.Priority=High
+
+# Combine filters with logical operators
+TestCategory=UnitTest&Trait.Owner=TeamA
+```
+
+For detailed information about test filtering capabilities, including syntax, operators, examples, and best practices, see the [Test Filter Guide](TestFilterGuide.md).
+
+## Related Packages
+
+* [gdUnit4.api](../api/README.md) - The core testing framework
+* [gdUnit4.analyzers](../analyzers/README.md) - Add compile-time validation for your test code
+
+## Documentation
+
+The full documentation can be found [here](https://mikeschulze.github.io/gdUnit4/csharp_project_setup/vstest-adapter/).
 
 ### You Are Welcome To
 
@@ -35,11 +84,14 @@ The full documentation can be found [here](https://mikeschulze.github.io/gdUnit4
 ### Contribution Guidelines
 
 **Thank you for your interest in contributing to GdUnit4!**<br>
-To ensure a smooth and collaborative contribution process, please review our [contribution guidelines](https://github.com/MikeSchulze/gdUnit4Net/blob/master/CONTRIBUTING.md) before getting started. These guidelines outline the standards and expectations we uphold in this project.
+To ensure a smooth and collaborative contribution process, please review our [contribution guidelines](https://github.com/MikeSchulze/gdUnit4Net/blob/master/CONTRIBUTING.md) before
+getting started. These guidelines outline the standards and expectations we uphold in this project.
 
-Code of Conduct: We strictly adhere to the Godot code of conduct in this project. As a contributor, it is important to respect and follow this code to maintain a positive and inclusive community.
+Code of Conduct: We strictly adhere to the Godot code of conduct in this project. As a contributor, it is important to respect and follow this code to maintain a positive and
+inclusive community.
 
-Using GitHub Issues: We utilize GitHub issues for tracking feature requests and bug reports. If you have a general question or wish to engage in discussions, we recommend joining the [GdUnit Discord Server](https://discord.gg/rdq36JwuaJ) for specific inquiries.
+Using GitHub Issues: We utilize GitHub issues for tracking feature requests and bug reports. If you have a general question or wish to engage in discussions, we recommend joining
+the [GdUnit Discord Server](https://discord.gg/rdq36JwuaJ) for specific inquiries.
 
 We value your input and appreciate your contributions to make GdUnit4 even better!
 
@@ -51,6 +103,6 @@ We value your input and appreciate your contributions to make GdUnit4 even bette
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](../LICENSE) file for details.
 
 ---

--- a/testadapter/TestFilterGuide.md
+++ b/testadapter/TestFilterGuide.md
@@ -1,0 +1,339 @@
+﻿# GdUnit4 Test Filter Usage Guide
+
+## Introduction
+
+GdUnit4 supports VSTest filtering capabilities, allowing you to selectively run tests based on various criteria such as
+test name, class, namespace, category, and custom traits. This functionality integrates with the standard VSTest
+platform's filtering syntax and can be used from the command line, Visual Studio, Visual Studio Code, or Rider.
+
+## Supported Filter Properties
+
+The following properties can be used for filtering:
+
+| Property               | Description                                 | Example                                             |
+|------------------------|---------------------------------------------|-----------------------------------------------------|
+| **FullyQualifiedName** | The fully qualified name of the test method | `FullyQualifiedName=MyNamespace.MyClass.TestMethod` |
+| **Name**               | The display name of the test                | `Name=TestAddition`                                 |
+| **Class**              | The class name containing the test          | `Class=CalculatorTests`                             |
+| **Namespace**          | The namespace of the test class             | `Namespace=MyProject.Tests`                         |
+| **TestCategory**       | The category assigned to the test           | `TestCategory=UnitTest`                             |
+| **Trait.{name}**       | Custom traits                               | `Trait.Owner=TeamA`                                 |
+
+## Filter Syntax
+
+The basic filter syntax follows this pattern:
+
+```
+PropertyName=Value
+```
+
+### Comparison Operators
+
+The following comparison operators are supported:
+
+| Operator | Description      | Example                         |
+|----------|------------------|---------------------------------|
+| `=`      | Equal to         | `TestCategory=UnitTest`         |
+| `!=`     | Not equal to     | `TestCategory!=IntegrationTest` |
+| `~`      | Contains         | `FullyQualifiedName~Calculator` |
+| `!~`     | Does not contain | `Name!~Legacy`                  |
+
+### Logical Operators
+
+You can combine multiple conditions using logical operators:
+
+| Operator | Description | Example                                    |
+|----------|-------------|--------------------------------------------|
+| `&`      | AND         | `TestCategory=UnitTest&Class=Calculator`   |
+| `\|`     | OR          | `TestCategory=UnitTest\|TestCategory=Fast` |
+| `!`      | NOT         | `!TestCategory=SlowTest`                   |
+
+You can also use parentheses to group expressions:
+
+```
+(TestCategory=UnitTest|TestCategory=Fast)&Namespace=MyProject.Tests
+```
+
+## Categorizing Tests
+
+GdUnit4 provides two ways to categorize your tests: using the `TestCategory` attribute or using the more flexible
+`Trait` attribute.
+
+### Using TestCategory
+
+The `TestCategory` attribute is the simplest way to categorize tests:
+
+```csharp
+using GdUnit4.Attributes;
+
+[TestSuite]
+public class CalculatorTests
+{
+    [TestCase]
+    [TestCategory("UnitTest")]
+    [TestCategory("Math")]
+    public void TestAddition()
+    {
+        // Test code here
+    }
+}
+```
+
+You can also apply categories at the class level to categorize all tests in a class:
+
+```csharp
+using GdUnit4.Attributes;
+
+[TestSuite]
+[TestCategory("Integration")]
+public class DatabaseTests 
+{
+    [TestCase]
+    public void TestConnection() 
+    {
+        // All tests in this class will have the "Integration" category
+    }
+}
+```
+
+### Using Traits
+
+The `Trait` attribute provides a more flexible key-value approach:
+
+```csharp
+using GdUnit4.Attributes;
+
+[TestSuite]
+public class UserServiceTests
+{
+    [TestCase]
+    [Trait("Category", "Integration")]
+    [Trait("Owner", "TeamA")]
+    [Trait("Priority", "High")]
+    public void TestUserRegistration()
+    {
+        // Test code here
+    }
+}
+```
+
+Like `TestCategory`, traits can also be applied at the class level:
+
+```csharp
+using GdUnit4.Attributes;
+
+[TestSuite]
+[Trait("Category", "Performance")]
+[Trait("Environment", "Production")]
+public class BenchmarkTests 
+{
+    // All tests in this class will have these traits
+}
+```
+
+## Using Test Filters
+
+### From Command Line
+
+When using the `dotnet test` command, you can apply filters with the `--filter` option:
+
+```bash
+dotnet test --filter "TestCategory=UnitTest"
+```
+
+Multiple filters can be applied:
+
+```bash
+dotnet test --filter "(TestCategory=UnitTest|TestCategory=Fast)&Namespace=MyProject.Tests"
+```
+
+### From Visual Studio
+
+1. Go to Test Explorer
+2. Click on the filter icon (or press Ctrl+E, T)
+3. Enter your filter expression in the search box
+4. Press Enter to apply the filter
+
+### From Visual Studio Code
+
+If you're using the .NET Test Explorer extension:
+
+1. Open the Test Explorer view
+2. Click on the filter icon
+3. Enter your filter expression
+4. Press Enter to apply the filter
+
+### From Rider
+
+1. Go to the Unit Tests window
+2. Click on the filter icon
+3. Enter your filter expression
+4. Press Enter to apply the filter
+
+## Filter Examples
+
+Here are some practical examples:
+
+### Running tests by category
+
+```
+TestCategory=UnitTest
+```
+
+### Running tests from a specific namespace
+
+```
+Namespace=GdUnit4.Tests.Core
+```
+
+### Running tests from a specific class that aren't integration tests
+
+```
+Class=CalculatorTests&TestCategory!=Integration
+```
+
+### Running tests that match specific naming patterns
+
+```
+FullyQualifiedName~Test.*Add.*
+```
+
+### Running tests with specific traits
+
+```
+Trait.Owner=TeamA
+```
+
+### Running tests with complex conditions
+
+```
+(TestCategory=UnitTest|TestCategory=Fast)&Class=CalculatorTests
+```
+
+### Running tests that don't contain a specific string in their name
+
+```
+Name!~Legacy
+```
+
+### Running only high priority tests from a specific component
+
+```
+Trait.Priority=High&Trait.Component=Core
+```
+
+## Implementation Details
+
+### How Categories and Traits Work Together
+
+When you use both `TestCategory` attributes and `Trait` attributes with a name of "Category", they're combined. This
+means that all of the following are treated as categories:
+
+```csharp
+[TestCategory("UnitTest")]
+[Trait("Category", "Fast")]
+public void TestMethod()
+{
+    // This test has both "UnitTest" and "Fast" categories
+}
+```
+
+### Inheritance of Categories and Traits
+
+Categories and traits defined at the class level are inherited by all test methods in the class. If a test method
+defines its own categories or traits, they are combined with those from the class.
+
+```csharp
+[TestSuite]
+[TestCategory("Integration")]
+public class DatabaseTests 
+{
+    [TestCase]
+    // Inherits "Integration" category from the class
+    public void TestConnection() { }
+    
+    [TestCase]
+    [TestCategory("Slow")]
+    // Has both "Integration" and "Slow" categories
+    public void TestBulkInsert() { }
+}
+```
+
+### VSTest Platform Integration
+
+GdUnit4's filter implementation is built on top of the VSTest platform's filtering capabilities, ensuring compatibility
+with all VSTest tools:
+
+- Visual Studio Test Explorer
+- VSCode .NET Test Explorer
+- JetBrains Rider
+- Command line (`dotnet test`)
+
+This means the syntax and behavior match what you'd expect from other .NET testing frameworks.
+
+## Best Practices
+
+1. **Use Categories Consistently**
+    - Establish a consistent set of categories across your test suite
+    - Document your category system for team reference
+    - Consider standard categories like "UnitTest", "IntegrationTest", "Fast", "Slow"
+
+2. **Leverage Class-Level Categories**
+    - Apply categories at the class level when all tests in a class share a category
+    - This reduces repetition and makes your code more maintainable
+
+3. **Combine with Test Runner Configuration**
+    - Use filters in combination with test runner configuration for CI/CD pipelines
+    - For example, run only fast unit tests during regular builds, and all tests in nightly builds
+
+4. **Use Traits for Rich Metadata**
+    - Use traits for additional metadata beyond simple categorization
+    - Good candidates for traits include "Owner", "Priority", "Feature", "Component"
+
+5. **Limit Trait Proliferation**
+    - Avoid creating too many different trait names
+    - Standardize trait names and values across your team
+
+## Common Filter Patterns for CI/CD
+
+Here are some filter patterns that are useful in CI/CD pipelines:
+
+### Fast Tests for PR Builds
+
+```bash
+dotnet test --filter "TestCategory=UnitTest|TestCategory=Fast"
+```
+
+### Integration Tests for Nightly Builds
+
+```bash
+dotnet test --filter "TestCategory=IntegrationTest"
+```
+
+### Component-Specific Tests for Feature Branches
+
+```bash
+dotnet test --filter "Trait.Component=Authentication"
+```
+
+### Critical Tests for Quick Feedback
+
+```bash
+dotnet test --filter "Trait.Priority=High"
+```
+
+## Troubleshooting
+
+If your filters aren't working as expected, try these troubleshooting steps:
+
+1. **Check Filter Syntax**: Ensure your filter expression is correctly formatted
+2. **Verify Test Attributes**: Check that the tests have the correct attributes applied
+3. **Use Simple Filters First**: Start with simple filters and gradually add complexity
+4. **Escape Special Characters**: Some shells require escaping of characters like `|` and `&`
+5. **Quotes in Command Line**: When using filters from the command line, wrap the filter expression in quotes
+
+## Conclusion
+
+Test filtering provides a powerful way to manage large test suites and focus on relevant tests. With GdUnit4's support
+for both `TestCategory` and `Trait` attributes, you have flexible options for organizing and selectively running your
+tests.

--- a/testadapter/src/GdUnit4TestDiscoverer.cs
+++ b/testadapter/src/GdUnit4TestDiscoverer.cs
@@ -3,12 +3,10 @@ namespace GdUnit4.TestAdapter;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.IO;
 using System.Linq;
 
 using Api;
 
-using Microsoft.TestPlatform.AdapterUtilities;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -83,7 +81,7 @@ public sealed class GdUnit4TestDiscoverer : ITestDiscoverer
         }
     }
 
-    private TestCase BuildTestCase(TestCaseDescriptor descriptor, GdUnit4Settings settings)
+    internal static TestCase BuildTestCase(TestCaseDescriptor descriptor, GdUnit4Settings settings)
     {
         TestCase testCase = new(descriptor.FullyQualifiedName, new Uri(GdUnit4TestExecutor.ExecutorUri), descriptor.AssemblyPath)
         {
@@ -92,30 +90,12 @@ public sealed class GdUnit4TestDiscoverer : ITestDiscoverer
             CodeFilePath = descriptor.CodeFilePath,
             LineNumber = descriptor.LineNumber
         };
-        testCase.SetPropertyValue(TestCaseNameProperty, descriptor.FullyQualifiedName);
-        testCase.SetPropertyValue(ManagedTypeProperty, descriptor.ManagedType);
-        testCase.SetPropertyValue(ManagedMethodProperty, descriptor.ManagedMethod);
-        testCase.SetPropertyValue(ManagedMethodAttributeIndexProperty, descriptor.AttributeIndex);
-        testCase.SetPropertyValue(RequireRunningGodotEngineProperty, descriptor.RequireRunningGodotEngine);
 
-        var parts = SplitByNamespace(descriptor.ManagedType);
-        var hierarchyValues = new string[HierarchyConstants.Levels.TotalLevelCount];
-        hierarchyValues[HierarchyConstants.Levels.ContainerIndex] = Path.GetFileNameWithoutExtension(descriptor.AssemblyPath);
-        hierarchyValues[HierarchyConstants.Levels.NamespaceIndex] = parts.namespaceName;
-        hierarchyValues[HierarchyConstants.Levels.ClassIndex] = parts.className;
-        hierarchyValues[HierarchyConstants.Levels.TestGroupIndex] = descriptor.ManagedMethod;
-        testCase.SetPropertyValue(HierarchyProperty, hierarchyValues);
+        testCase.SetPropertyValues(descriptor);
 
         return testCase;
     }
 
-    private static (string namespaceName, string className) SplitByNamespace(string managedType)
-    {
-        var parts = managedType.Split('.');
-        var namespaceName = parts.Length == 1 ? "" : string.Join(".", parts.Take(parts.Length - 1));
-        var className = parts.Last();
-        return (namespaceName, className);
-    }
 
     private static string GetDisplayName(TestCaseDescriptor input, GdUnit4Settings gdUnitSettings)
         => gdUnitSettings.DisplayName switch

--- a/testadapter/src/GdUnit4TestExecutor.cs
+++ b/testadapter/src/GdUnit4TestExecutor.cs
@@ -36,13 +36,6 @@ public class GdUnit4TestExecutor : ITestExecutor2, IDisposable
     /// </summary>
     private const int DEFAULT_SESSION_TIMEOUT = 600000;
 
-    // Test properties supported for filtering
-    private readonly Dictionary<string, TestProperty> supportedProperties = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["FullyQualifiedName"] = TestCaseProperties.FullyQualifiedName,
-        ["Name"] = TestCaseProperties.DisplayName
-    };
-
     private IFrameworkHandle? fh;
     private ITestEngine? testEngine;
 
@@ -97,16 +90,11 @@ public class GdUnit4TestExecutor : ITestExecutor2, IDisposable
             : $"Set test session timeout to: {TimeSpan.FromMilliseconds(engineSettings.SessionTimeout)}");
 
         //var runSettings = XmlRunSettingsUtilities.GetTestRunParameters(runContext.RunSettings?.SettingsXml);
-        // ReSharper disable once UnusedVariable
-        var filterExpression = runContext.GetTestCaseFilter(supportedProperties.Keys, propertyName =>
-        {
-            supportedProperties.TryGetValue(propertyName, out var testProperty);
-            return testProperty;
-        });
 
         try
         {
             SetupRunnerEnvironment(runContext, frameworkHandle);
+            testCases = new TestCaseFilter(runContext, Log).Execute(testCases);
             var testsByAssembly = ToGdUnitTestNodes(testCases);
             var testEventListener = new TestEventReportListener(frameworkHandle, testCases);
             var debuggerFramework = GetDebuggerFramework(frameworkHandle);

--- a/testadapter/src/execution/TestCaseFilter.cs
+++ b/testadapter/src/execution/TestCaseFilter.cs
@@ -1,0 +1,52 @@
+﻿namespace GdUnit4.TestAdapter.Execution;
+
+using System.Collections.Generic;
+using System.Linq;
+
+using Api;
+
+using Extensions;
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+/// <summary>
+///     Implementation for filtering test cases.
+/// </summary>
+public class TestCaseFilter
+{
+    private readonly ITestCaseFilterExpression? filterExpression;
+
+    public TestCaseFilter(IRunContext runContext, ITestEngineLogger logger)
+    {
+        try
+        {
+            filterExpression = runContext.GetTestCaseFilter(
+                TestCaseExtensions.SupportedProperties.Keys,
+                TestCaseExtensions.GetPropertyProvider());
+        }
+
+        catch (TestPlatformFormatException e)
+        {
+            logger.LogError(e.Message);
+        }
+    }
+
+    /// <summary>
+    ///     Runs the filter on the provided test cases and returns the filtered collection.
+    /// </summary>
+    /// <param name="testCases">The collection of test cases to filter</param>
+    /// <returns>The filtered collection of test cases or the original collection if the filter is null</returns>
+    public List<TestCase> Execute(List<TestCase> testCases) =>
+        filterExpression == null
+            ? testCases
+            : testCases.Where(MatchTestCase).ToList();
+
+    /// <summary>
+    ///     Determines if a test case matches the filter criteria.
+    /// </summary>
+    /// <param name="testCase">Test case to evaluate</param>
+    /// <returns>True if the test case matches the filter, false otherwise</returns>
+    private bool MatchTestCase(TestCase testCase)
+        => filterExpression?.MatchTestCase(testCase, testCase.GetPropertyValue) ?? false;
+}

--- a/testadapter/src/extensions/TestCaseExtensions.cs
+++ b/testadapter/src/extensions/TestCaseExtensions.cs
@@ -1,5 +1,12 @@
 namespace GdUnit4.TestAdapter.Extensions;
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using Core.Discovery;
+
 using Microsoft.TestPlatform.AdapterUtilities;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
@@ -8,24 +15,19 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 /// </summary>
 internal static class TestCaseExtensions
 {
-    public const string ManagedMethodAttributeIndexLabel = "ManagedAttributeIndexLabel";
-
-    public const string ManagedMethodAttributeIndexId = $"TestCase.{ManagedMethodAttributeIndexLabel}";
-
-
-    internal static readonly TestProperty TestCaseNameProperty = TestProperty.Register(
-        "TestCase.Name",
-        "Name",
+    internal static readonly TestProperty NamespaceProperty = TestProperty.Register(
+        "TestCase.Namespace",
+        "Namespace",
         string.Empty,
-        string.Empty,
+        "The namespace containing the test",
         typeof(string),
-        o => !string.IsNullOrWhiteSpace(o as string),
+        o => o is string,
         TestPropertyAttributes.Hidden,
         typeof(TestCase));
 
     internal static readonly TestProperty ManagedTypeProperty = TestProperty.Register(
-        ManagedNameConstants.ManagedTypePropertyId,
-        ManagedNameConstants.ManagedTypeLabel,
+        "TestCase.Class",
+        "Class",
         string.Empty,
         "holds the test suite class name",
         typeof(string),
@@ -44,8 +46,8 @@ internal static class TestCaseExtensions
         typeof(TestCase));
 
     internal static readonly TestProperty ManagedMethodAttributeIndexProperty = TestProperty.Register(
-        ManagedMethodAttributeIndexId,
-        ManagedMethodAttributeIndexLabel,
+        "TestCase.ManagedMethodAttributeIndex",
+        "ManagedAttributeIndex",
         string.Empty,
         "Holds the test method attribute index",
         typeof(int),
@@ -54,8 +56,8 @@ internal static class TestCaseExtensions
         typeof(TestCase));
 
     internal static readonly TestProperty RequireRunningGodotEngineProperty = TestProperty.Register(
-        "TestCase.RequireRunningGodotEngineLabel",
-        "RequireRunningGodotEngineLabel",
+        "TestCase.RequireRunningGodotEngine",
+        "RequireRunningGodotEngine",
         string.Empty,
         "Indicates that the test method must execute inside Godot engine context.",
         typeof(bool),
@@ -63,8 +65,7 @@ internal static class TestCaseExtensions
         TestPropertyAttributes.Hidden,
         typeof(TestCase));
 
-
-    internal static readonly TestProperty HierarchyProperty = TestProperty.Register(
+    private static readonly TestProperty HierarchyProperty = TestProperty.Register(
         HierarchyConstants.HierarchyPropertyId,
         HierarchyConstants.HierarchyLabel,
         string.Empty,
@@ -73,4 +74,98 @@ internal static class TestCaseExtensions
         null,
         TestPropertyAttributes.Immutable,
         typeof(TestCase));
+
+    // Added property for category filtering
+    internal static readonly TestProperty TestCategoryProperty = TestProperty.Register(
+        "TestCase.TestCategory",
+        "TestCategory",
+        //string.Empty,
+        //"The category assigned to the test",
+        typeof(string[]),
+        //null,
+        TestPropertyAttributes.Immutable,
+        typeof(TestCase));
+
+    // Filter properties for use in test filtering
+    internal static readonly Dictionary<string, TestProperty> SupportedProperties = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [TestCaseProperties.DisplayName.Label] = TestCaseProperties.DisplayName,
+        [TestCaseProperties.FullyQualifiedName.Label] = TestCaseProperties.FullyQualifiedName,
+        [NamespaceProperty.Label] = NamespaceProperty,
+        [ManagedTypeProperty.Label] = ManagedTypeProperty,
+        [ManagedMethodProperty.Label] = ManagedMethodProperty,
+        [ManagedMethodAttributeIndexProperty.Label] = ManagedMethodAttributeIndexProperty,
+        [RequireRunningGodotEngineProperty.Label] = RequireRunningGodotEngineProperty,
+        [HierarchyProperty.Label] = HierarchyProperty,
+        [TestCategoryProperty.Label] = TestCategoryProperty
+    };
+
+    public static void AddTrait(this TestCase testCase, string name, string value) =>
+        testCase.Traits.Add(new Trait(name, value));
+
+    public static void SetPropertyValues(this TestCase testCase, TestCaseDescriptor descriptor)
+    {
+        var parts = SplitByNamespace(descriptor.ManagedType);
+        var hierarchyValues = new string[HierarchyConstants.Levels.TotalLevelCount];
+        hierarchyValues[HierarchyConstants.Levels.ContainerIndex] = Path.GetFileNameWithoutExtension(descriptor.AssemblyPath);
+        hierarchyValues[HierarchyConstants.Levels.NamespaceIndex] = parts.namespaceName;
+        hierarchyValues[HierarchyConstants.Levels.ClassIndex] = parts.className;
+        hierarchyValues[HierarchyConstants.Levels.TestGroupIndex] = descriptor.ManagedMethod;
+        testCase.SetPropertyValue(HierarchyProperty, hierarchyValues);
+        testCase.SetPropertyValue(NamespaceProperty, parts.namespaceName);
+        testCase.SetPropertyValue(ManagedTypeProperty, descriptor.ManagedType);
+        testCase.SetPropertyValue(ManagedMethodProperty, descriptor.ManagedMethod);
+        //testCase.SetPropertyValue(TestCaseProperties.DisplayName, descriptor.ManagedMethod);
+        testCase.SetPropertyValue(TestCaseProperties.FullyQualifiedName, descriptor.FullyQualifiedName);
+        testCase.SetPropertyValue(ManagedMethodAttributeIndexProperty, descriptor.AttributeIndex);
+        testCase.SetPropertyValue(RequireRunningGodotEngineProperty, descriptor.RequireRunningGodotEngine);
+        testCase.SetPropertyValue(TestCategoryProperty, descriptor.Categories.ToArray());
+
+        // Add traits
+        descriptor.Traits
+            .SelectMany(group => group.Value, (group, value) => new Trait(group.Key, value))
+            .ToList()
+            .ForEach(testCase.Traits.Add);
+    }
+
+    /// <summary>
+    ///     Gets the property provider function for use with GetTestCaseFilter.
+    /// </summary>
+    /// <returns>A function that returns a TestProperty for a given property name</returns>
+    public static Func<string, TestProperty?> GetPropertyProvider() =>
+        propertyName => SupportedProperties.GetValueOrDefault(propertyName);
+
+    /// <summary>
+    ///     Gets the value of a property from a test case.
+    /// </summary>
+    /// <param name="testCase">The test case</param>
+    /// <param name="propertyName">The name of the property</param>
+    /// <returns>The property value or null if not found</returns>
+    internal static object? GetPropertyValue(this TestCase testCase, string propertyName) =>
+        SupportedProperties.TryGetValue(propertyName, out var testProperty)
+            ? testCase.GetPropertyValue(testProperty)
+            : testCase.GetPropertyTraits(propertyName);
+
+    private static object? GetPropertyTraits(this TestCase testCase, string propertyName)
+    {
+        if (testCase.Traits.Any() && propertyName.StartsWith("Trait.", StringComparison.OrdinalIgnoreCase))
+        {
+            var traitName = propertyName.Substring("Trait.".Length);
+
+            return testCase.Traits
+                .Where(t => string.Equals(t.Name, traitName, StringComparison.OrdinalIgnoreCase))
+                .Select(t => t.Value)
+                .ToArray();
+        }
+
+        return null;
+    }
+
+    private static (string namespaceName, string className) SplitByNamespace(string managedType)
+    {
+        var parts = managedType.Split('.');
+        var namespaceName = parts.Length == 1 ? "" : string.Join(".", parts.Take(parts.Length - 1));
+        var className = parts.Last();
+        return (namespaceName, className);
+    }
 }


### PR DESCRIPTION
# Why
We want to support the VSTest filter framework to allow users to selectively run tests based on various criteria, improving test workflow efficiency.

# What
- Implement test filtering for VSTest integration
- Add TestCategoryAttribute for grouping related tests
- Add TraitAttribute for custom metadata and flexible filtering
- Create comprehensive TestFilterGuide.md documentation
- Update all README files with filter information and cross-references
- Add example filter syntax and usage patterns in documentation

This enables users to run specific tests using criteria like name, class, namespace, category, and custom traits across Visual Studio, VS Code, and JetBrains Rider.