### PR TITLE
Add code style enforcement for consistent formatting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,36 @@
 /README.md             export-ignore
 
 /test   export-ignore
+
+# Set default behavior to automatically normalize line endings
+* text=auto
+
+# Explicitly declare text files to be normalized and converted to native line endings on checkout
+*.cs text
+*.csproj text
+*.sln text
+*.md text
+*.json text
+*.props text
+*.targets text
+*.yml text
+*.yaml text
+*.xml text
+*.config text
+*.editorconfig text
+
+# Declare files that will always have CRLF line endings on checkout (Windows-specific)
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Declare files that will always have LF line endings on checkout (Unix-specific)
+*.sh text eol=lf
+
+# Denote all files that are truly binary and should not be modified
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.dll binary
+*.pdb binary
+*.zip binary

--- a/Analyzers/.editorconfig
+++ b/Analyzers/.editorconfig
@@ -1,0 +1,590 @@
+# Version: 4.1.1 (Using https://semver.org/)
+# Updated: 2022-05-23
+# See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
+# See https://github.com/RehanSaeed/EditorConfig for updates to this file.
+# See http://EditorConfig.org for more information about .editorconfig files.
+
+##########################################
+# Common Settings
+##########################################
+
+# This file is the top-most EditorConfig file
+root = true
+
+# All Files
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 180
+# Roslynator settings for line length
+roslynator_max_line_length = max_line_length
+resharper_wrap_lines = true
+resharper_hard_wrap_line_length = max_line_length
+
+# Code style rules for line breaks
+csharp_max_line_length = max_line_length
+
+##########################################
+# File Extension Settings
+##########################################
+
+# Visual Studio Solution Files
+[*.sln]
+indent_style = tab
+
+# Visual Studio XML Project Files
+[*.{csproj,vbproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# XML Configuration Files
+[*.{xml,config,props,targets,nuspec,resx,ruleset,vsixmanifest,vsct}]
+indent_size = 2
+
+# JSON Files
+[*.{json,json5,webmanifest}]
+indent_size = 2
+
+# YAML Files
+[*.{yml,yaml}]
+indent_size = 2
+
+# Markdown Files
+[*.{md,mdx}]
+trim_trailing_whitespace = false
+
+# Web Files
+[*.{htm,html,js,jsm,ts,tsx,cjs,cts,ctsx,mjs,mts,mtsx,css,sass,scss,less,pcss,svg,vue}]
+indent_size = 2
+
+# Batch Files
+[*.{cmd,bat}]
+end_of_line = crlf
+
+# Bash Files
+[*.sh]
+end_of_line = lf
+
+# Makefiles
+[Makefile]
+indent_style = tab
+
+##########################################
+# Default .NET Code Style Severities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/configuration-options#scope
+##########################################
+
+[*.{cs,csx,cake,vb,vbx}]
+# Default Severity for all .NET Code Style rules below
+dotnet_analyzer_diagnostic.severity = warning
+
+##########################################
+# Language Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules
+##########################################
+
+# .NET Style Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#net-style-rules
+[*.{cs,csx,cake,vb,vbx}]
+# "this." and "Me." qualifiers
+dotnet_style_qualification_for_field = true : warning
+dotnet_style_qualification_for_property = true : warning
+dotnet_style_qualification_for_method = true : warning
+dotnet_style_qualification_for_event = true : warning
+
+# Member ordering rules
+dotnet_diagnostic.SA1201.severity = warning # Elements should appear in the correct order
+dotnet_diagnostic.SA1202.severity = warning # Elements should be ordered by access
+dotnet_diagnostic.SA1203.severity = warning # Constants should appear before fields
+dotnet_diagnostic.SA1204.severity = warning # Static elements should appear before instance elements
+
+# Member ordering - SA1202 fix - enforce ordering by access level
+dotnet_diagnostic.SA1202.severity = error
+resharper_member_modifier_order = internal static, protected static, private static, static, internal, protected, private
+resharper_access_level_order = internal, protected, private
+resharper_member_order = accessibility, constant_fields, static_fields, fields, constructors, finalizers, properties, events, operators, methods
+
+# Sort using directives
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = true
+
+# Format document on save - for JetBrains Rider
+resharper_apply_on_save = true
+
+
+# Language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true : warning
+dotnet_style_predefined_type_for_member_access = true : warning
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = always : warning
+csharp_preferred_modifier_order = public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async : warning
+visual_basic_preferred_modifier_order = Partial, Default, Private, Protected, Public, Friend, NotOverridable, Overridable, MustOverride, Overloads, Overrides, MustInherit, NotInheritable, Static, Shared, Shadows, ReadOnly, WriteOnly, Dim, Const, WithEvents, Widening, Narrowing, Custom, Async : warning
+dotnet_style_readonly_field = true : warning
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity : warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity : warning
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity : warning
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary : warning
+# Expression-level preferences
+dotnet_style_object_initializer = true : warning
+dotnet_style_collection_initializer = true : warning
+dotnet_style_explicit_tuple_names = true : warning
+dotnet_style_prefer_inferred_tuple_names = true : warning
+dotnet_style_prefer_inferred_anonymous_type_member_names = true : warning
+dotnet_style_prefer_auto_properties = true : warning
+dotnet_style_prefer_conditional_expression_over_assignment = false : suggestion
+dotnet_diagnostic.IDE0045.severity = suggestion
+dotnet_style_prefer_conditional_expression_over_return = false : suggestion
+dotnet_diagnostic.IDE0046.severity = suggestion
+dotnet_style_prefer_compound_assignment = true : warning
+dotnet_style_prefer_simplified_interpolation = true : warning
+dotnet_style_prefer_simplified_boolean_expressions = true : warning
+# Null-checking preferences
+dotnet_style_coalesce_expression = true : warning
+dotnet_style_null_propagation = true : warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true : warning
+# File header preferences
+# file_header_template = <copyright file="{fileName}" company="PROJECT-AUTHOR">\n© PROJECT-AUTHOR\n</copyright>
+# If you use StyleCop, you'll need to disable SA1636: File header copyright text should match.
+dotnet_diagnostic.SA1633.severity = none
+
+# Set C# new line preferences
+# Controls placement of binary operators when wrapping expressions
+# Place operators at the beginning of the line (Rider/ReSharper specific setting)
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+csharp_new_line_before_binary_operators = false
+
+# C# Style Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#c-style-rules
+[*.{cs,csx,cake}]
+# 'var' preferences
+csharp_style_var_for_built_in_types = true : warning
+csharp_style_var_when_type_is_apparent = true : warning
+csharp_style_var_elsewhere = true : warning
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true : warning
+csharp_style_expression_bodied_constructors = true : warning
+csharp_style_expression_bodied_operators = true : warning
+csharp_style_expression_bodied_properties = true : warning
+csharp_style_expression_bodied_indexers = true : warning
+csharp_style_expression_bodied_accessors = true : warning
+csharp_style_expression_bodied_lambdas = true : warning
+csharp_style_expression_bodied_local_functions = true : warning
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true : warning
+csharp_style_pattern_matching_over_as_with_null_check = true : warning
+csharp_style_prefer_switch_expression = true : warning
+csharp_style_prefer_pattern_matching = true : warning
+csharp_style_prefer_not_pattern = true : warning
+# Expression-level preferences
+csharp_style_inlined_variable_declaration = true : warning
+csharp_prefer_simple_default_expression = true : warning
+csharp_style_pattern_local_over_anonymous_function = true : warning
+csharp_style_deconstructed_variable_declaration = true : warning
+csharp_style_prefer_index_operator = true : warning
+csharp_style_prefer_range_operator = true : warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true : warning
+# "Null" checking preferences
+csharp_style_throw_expression = true : warning
+csharp_style_conditional_delegate_call = true : warning
+# Code block preferences
+csharp_prefer_braces = when_multiline : warning
+csharp_prefer_simple_using_statement = true : suggestion
+dotnet_diagnostic.IDE0063.severity = suggestion
+# 'using' directive preferences
+csharp_using_directive_placement = inside_namespace : warning
+# Modifier preferences
+csharp_prefer_static_local_function = true : warning
+# Disable StyleCop rule for requiring braces for single-line statements
+dotnet_diagnostic.SA1503.severity = none
+
+##########################################
+# Unnecessary Code Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/unnecessary-code-rules
+##########################################
+
+# .NET Unnecessary code rules
+[*.{cs,csx,cake,vb,vbx}]
+dotnet_code_quality_unused_parameters = all : warning
+dotnet_remove_unnecessary_suppression_exclusions = none : warning
+
+# C# Unnecessary code rules
+[*.{cs,csx,cake}]
+csharp_style_unused_value_expression_statement_preference = discard_variable : suggestion
+dotnet_diagnostic.IDE0058.severity = suggestion
+csharp_style_unused_value_assignment_preference = discard_variable : suggestion
+dotnet_diagnostic.IDE0059.severity = suggestion
+
+
+##########################################
+# Test suite rules
+##########################################
+# Exclude test files from certain rules
+[**/*Test.cs]
+dotnet_diagnostic.CA1515.severity = none
+
+##########################################
+# Formatting Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules
+##########################################
+
+# .NET formatting rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#net-formatting-rules
+[*.{cs,csx,cake,vb,vbx}]
+# Organize using directives
+dotnet_sort_system_directives_first = true
+# Dotnet namespace options
+dotnet_style_namespace_match_folder = true : suggestion
+dotnet_diagnostic.IDE0130.severity = suggestion
+# Disable requirement for qualified using directives
+dotnet_diagnostic.SA1135.severity = none
+
+# C# formatting rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#c-formatting-rules
+[*.{cs,csx,cake}]
+# Newline options
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#new-line-options
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation options
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#indentation-options
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = no_change
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents_when_block = false
+# Spacing options
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#spacing-options
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_after_comma = true
+csharp_space_before_comma = false
+csharp_space_after_dot = false
+csharp_space_before_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_around_declaration_statements = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_square_brackets = false
+
+# Specifically for new keyword space
+resharper_space_within_single_line_array_initializer_braces = true
+resharper_space_in_singleline_method = true
+resharper_space_after_new_expression = true
+resharper_space_after_type_parameter_constraint_colon = true
+dotnet_diagnostic.SA1000.severity = none
+
+
+# Wrap options
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#wrap-options
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
+# Namespace options
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#namespace-options
+csharp_style_namespace_declarations = file_scoped : warning
+# Disable StyleCop SA1118 (Parameter should not span multiple lines)
+dotnet_diagnostic.SA1118.severity = none
+
+
+##########################################
+# .NET Naming Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/naming-rules
+##########################################
+
+[*.{cs,csx,cake,vb,vbx}]
+
+##########################################
+# Styles
+##########################################
+
+# camel_case_style - Define the camelCase style
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+# pascal_case_style - Define the PascalCase style
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+# first_upper_style - The first character must start with an upper-case character
+dotnet_naming_style.first_upper_style.capitalization = first_word_upper
+# prefix_interface_with_i_style - Interfaces must be PascalCase and the first character of an interface must be an 'I'
+dotnet_naming_style.prefix_interface_with_i_style.capitalization = pascal_case
+dotnet_naming_style.prefix_interface_with_i_style.required_prefix = I
+# prefix_type_parameters_with_t_style - Generic Type Parameters must be PascalCase and the first character must be a 'T'
+dotnet_naming_style.prefix_type_parameters_with_t_style.capitalization = pascal_case
+dotnet_naming_style.prefix_type_parameters_with_t_style.required_prefix = T
+# disallowed_style - Anything that has this style applied is marked as disallowed
+dotnet_naming_style.disallowed_style.capitalization = pascal_case
+dotnet_naming_style.disallowed_style.required_prefix = ____RULE_VIOLATION____
+dotnet_naming_style.disallowed_style.required_suffix = ____RULE_VIOLATION____
+# internal_error_style - This style should never occur... if it does, it indicates a bug in file or in the parser using the file
+dotnet_naming_style.internal_error_style.capitalization = pascal_case
+dotnet_naming_style.internal_error_style.required_prefix = ____INTERNAL_ERROR____
+dotnet_naming_style.internal_error_style.required_suffix = ____INTERNAL_ERROR____
+
+##########################################
+# .NET Design Guideline Field Naming Rules
+# Naming rules for fields follow the .NET Framework design guidelines
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/index
+##########################################
+
+# All public/protected/protected_internal constant fields must be PascalCase
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.public_protected_constant_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.public_protected_constant_fields_group.required_modifiers = const
+dotnet_naming_symbols.public_protected_constant_fields_group.applicable_kinds = field
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.symbols = public_protected_constant_fields_group
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.style = pascal_case_style
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.severity = warning
+
+# All public/protected/protected_internal static readonly fields must be PascalCase
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.required_modifiers = static, readonly
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_kinds = field
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.symbols = public_protected_static_readonly_fields_group
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.style = pascal_case_style
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.severity = warning
+
+# No other public/protected/protected_internal fields are allowed
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.other_public_protected_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.other_public_protected_fields_group.applicable_kinds = field
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.symbols = other_public_protected_fields_group
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.style = disallowed_style
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.severity = error
+
+##########################################
+# StyleCop Field Naming Rules
+# Naming rules for fields follow the StyleCop analyzers
+# This does not override any rules using disallowed_style above
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers
+##########################################
+
+# All constant fields must be PascalCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
+dotnet_naming_style.all_caps_style.capitalization = all_upper
+dotnet_naming_symbols.stylecop_constant_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
+dotnet_naming_symbols.stylecop_constant_fields_group.required_modifiers = const
+dotnet_naming_symbols.stylecop_constant_fields_group.applicable_kinds = field
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.symbols = stylecop_constant_fields_group
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.style = all_caps_style
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.severity = warning
+
+# All static readonly fields must be PascalCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.required_modifiers = static, readonly
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_kinds = field
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.symbols = stylecop_static_readonly_fields_group
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.style = pascal_case_style
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.severity = warning
+
+# No non-private instance fields are allowed
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected
+dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_kinds = field
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.symbols = stylecop_fields_must_be_private_group
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.style = disallowed_style
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.severity = error
+
+# Private fields must be camelCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
+dotnet_naming_symbols.stylecop_private_fields_group.applicable_accessibilities = private
+dotnet_naming_symbols.stylecop_private_fields_group.applicable_kinds = field
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.symbols = stylecop_private_fields_group
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.style = camel_case_style
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.severity = warning
+
+# Local variables must be camelCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
+dotnet_naming_symbols.stylecop_local_fields_group.applicable_accessibilities = local
+dotnet_naming_symbols.stylecop_local_fields_group.applicable_kinds = local
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.symbols = stylecop_local_fields_group
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.style = camel_case_style
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.severity = silent
+
+# This rule should never fire.  However, it's included for at least two purposes:
+# First, it helps to understand, reason about, and root-case certain types of issues, such as bugs in .editorconfig parsers.
+# Second, it helps to raise immediate awareness if a new field type is added (as occurred recently in C#).
+dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_accessibilities = *
+dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_kinds = field
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.symbols = sanity_check_uncovered_field_case_group
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.style = internal_error_style
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.severity = error
+
+
+##########################################
+# Other Naming Rules
+##########################################
+
+# All of the following must be PascalCase:
+# - Namespaces
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-namespaces
+#   https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# - Classes and Enumerations
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+#   https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# - Delegates
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces#names-of-common-types
+# - Constructors, Properties, Events, Methods
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-type-members
+dotnet_naming_symbols.element_group.applicable_kinds = namespace, class, enum, struct, delegate, event, method, property
+dotnet_naming_rule.element_rule.symbols = element_group
+dotnet_naming_rule.element_rule.style = pascal_case_style
+dotnet_naming_rule.element_rule.severity = warning
+
+# Interfaces use PascalCase and are prefixed with uppercase 'I'
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+dotnet_naming_symbols.interface_group.applicable_kinds = interface
+dotnet_naming_rule.interface_rule.symbols = interface_group
+dotnet_naming_rule.interface_rule.style = prefix_interface_with_i_style
+dotnet_naming_rule.interface_rule.severity = warning
+
+# Generics Type Parameters use PascalCase and are prefixed with uppercase 'T'
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+dotnet_naming_symbols.type_parameter_group.applicable_kinds = type_parameter
+dotnet_naming_rule.type_parameter_rule.symbols = type_parameter_group
+dotnet_naming_rule.type_parameter_rule.style = prefix_type_parameters_with_t_style
+dotnet_naming_rule.type_parameter_rule.severity = warning
+
+# Function parameters use camelCase
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/naming-parameters
+dotnet_naming_symbols.parameters_group.applicable_kinds = parameter
+dotnet_naming_rule.parameters_rule.symbols = parameters_group
+dotnet_naming_rule.parameters_rule.style = camel_case_style
+dotnet_naming_rule.parameters_rule.severity = warning
+
+##########################################
+# License
+##########################################
+# The following applies as to the .editorconfig file ONLY, and is
+# included below for reference, per the requirements of the license
+# corresponding to this .editorconfig file.
+# See: https://github.com/RehanSaeed/EditorConfig
+#
+# MIT License
+#
+# Copyright (c) 2017-2019 Muhammad Rehan Saeed
+# Copyright (c) 2019 Henry Gabryjelski
+#
+# Permission is hereby granted, free of charge, to any
+# person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the
+# Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute,
+# sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject
+# to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+##########################################
+
+
+#########################################################################################################
+# GdUnit4 specific overrides
+#########################################################################################################
+
+# Configure file header template
+file_header_template = Copyright (c) 2025 Mike Schulze\nMIT License - See LICENSE file in the repository root for full license text
+# Enable file header rules
+dotnet_diagnostic.SA1633.severity = error # File must have header
+dotnet_diagnostic.SA1635.severity = error # File header must have copyright text
+dotnet_diagnostic.SA1637.severity = none # File header must contain file name
+dotnet_diagnostic.SA1638.severity = none # File header file name documentation must match file name
+dotnet_diagnostic.SA1634.severity = none # File header must show copyright
+
+# .NET formatting rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#net-formatting-rules
+[*.{cs,csx,cake,vb,vbx}]
+# Organize using directives
+dotnet_separate_import_directive_groups = true
+
+
+dotnet_diagnostic.CA1822.severity = none
+
+# Don't require culture info for ToString()
+dotnet_diagnostic.CA1304.severity = none
+# Don't require a string format specifier.
+dotnet_diagnostic.CA1305.severity = none
+# Don't require culture info for Specify StringComparison for correctness
+dotnet_diagnostic.CA1310.severity = none
+# Don't require culture info for String.ToUpper() or String.ToLower() without specifying a culture.
+dotnet_diagnostic.CA1311.severity = none
+
+# Default severity for analyzer diagnostics with category 'Usage'
+dotnet_analyzer_diagnostic.category-Usage.severity = warning
+
+# allow constant arrays as arguments
+dotnet_diagnostic.CA1861.severity = none
+
+#### Define naming rules for constants
+
+# Disable StyleCop's underscore rule that prevents SCREAMING_SNAKE_CASE
+dotnet_diagnostic.SA1310.severity = none
+
+# Define the symbol group (what the rule applies to)
+dotnet_naming_symbols.constants.applicable_kinds = field
+dotnet_naming_symbols.constants.required_modifiers = const
+dotnet_naming_symbols.constants.applicable_accessibilities = *
+# Define the naming style (how they should be named)
+dotnet_naming_style.all_upper_style.capitalization = all_upper
+dotnet_naming_style.all_upper_style.word_separator = _
+
+# Associate the naming rule
+dotnet_naming_rule.constants_should_be_all_upper.symbols = constants
+dotnet_naming_rule.constants_should_be_all_upper.style = all_upper_style
+dotnet_naming_rule.constants_should_be_all_upper.severity = error
+
+
+# Disable StyleCop SA1507 or configure it
+dotnet_diagnostic.SA1507.severity = warning # Set to 'none' to disable or 'warning'/'error' to enforce
+
+# ReSharper/Rider specific settings for blank lines
+resharper_blank_lines_after_block_statements = 1
+resharper_blank_lines_around_single_line_type = 1
+resharper_blank_lines_around_field = 1
+resharper_blank_lines_around_property = 1
+resharper_blank_lines_around_method = 1
+resharper_csharp_blank_lines_around_method = 1
+resharper_blank_lines_after_start_comment = 1
+resharper_blank_lines_before_single_line_comment = 1
+resharper_blank_lines_after_using_list = 1
+resharper_keep_blank_lines_in_code = 1
+resharper_csharp_keep_blank_lines_in_code = 1
+resharper_remove_blank_lines_near_braces = true
+resharper_blank_lines_between_using_groups = 1
+
+# Ensure Rider keeps 1 blank line max in declarations
+resharper_keep_blank_lines_in_declarations = 1
+resharper_csharp_keep_blank_lines_in_declarations = 1
+# Make sure this is at warning level to enforce the rule
+dotnet_diagnostic.SA1507.severity = error
+
+# ignore trailing commas
+dotnet_diagnostic.SA1413.severity = none

--- a/Analyzers/Directory.Build.props
+++ b/Analyzers/Directory.Build.props
@@ -1,0 +1,58 @@
+﻿<Project>
+  <!--
+  This Directory.Build.props file applies settings to all projects in this directory and subdirectories.
+  It ensures consistent code quality, style, and build configuration across the entire solution.
+  For a GdUnit4Net project, these settings help maintain high-quality test code.
+  -->
+
+  <PropertyGroup>
+    <!--
+    Analyzer Configuration:
+    These settings enable code analysis tools that help maintain code quality by
+    identifying potential issues, enforcing consistent style, and encouraging best practices.
+    -->
+
+    <!-- Enable built-in .NET code analyzers -->
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+
+    <!-- Use the latest analysis rules -->
+    <AnalysisLevel>latest</AnalysisLevel>
+
+    <!-- Enable all categories of analysis rules (Style, Design, Documentation, etc.) -->
+    <AnalysisMode>All</AnalysisMode>
+
+    <!-- Enforce code style rules during build, not just in the IDE -->
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+
+    <CodeAnalysisRuleSet>../stylecop.ruleset</CodeAnalysisRuleSet>
+
+    <!-- Convert all warnings to errors for stricter enforcement -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <!--
+    Generate XML documentation files from code comments
+    This enables full analyzer functionality and documents your test examples
+    -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!--
+  External Code Analyzers:
+  These packages provide additional rules beyond what's built into the .NET SDK.
+  They're configured as private assets so they don't get published with your assembly.
+  -->
+  <ItemGroup>
+    <!--
+    StyleCop.Analyzers: Enforces style and consistency rules
+    Helps ensure readable and maintainable code across the codebase
+    -->
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+
+    <!-- Required for stylecop.json configuration file to work -->
+    <AdditionalFiles Include="../stylecop.json"/>
+
+  </ItemGroup>
+</Project>

--- a/Analyzers/src/AssemblyInfo.cs
+++ b/Analyzers/src/AssemblyInfo.cs
@@ -1,3 +1,6 @@
-﻿using System.Runtime.CompilerServices;
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("gdUnit4Analyzers.Tests")]

--- a/Analyzers/src/DataPointAttributeAnalyzer.cs
+++ b/Analyzers/src/DataPointAttributeAnalyzer.cs
@@ -1,6 +1,10 @@
-﻿namespace GdUnit4.Analyzers;
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+namespace GdUnit4.Analyzers;
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
@@ -8,18 +12,34 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 using static DiagnosticRules;
 
+/// <summary>
+///     Analyzer that checks for improper usage of DataPoint attributes.
+///     Specifically, it ensures methods with DataPointAttribute don't have multiple TestCaseAttributes.
+/// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class DataPointAttributeAnalyzer : DiagnosticAnalyzer
 {
+    /// <summary>
+    ///     Gets the set of diagnostic descriptors supported by this analyzer.
+    /// </summary>
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DataPoint.MultipleTestCaseAttributes);
 
+    /// <summary>
+    ///     Initializes the analyzer with the analysis context.
+    /// </summary>
+    /// <param name="context">The analysis context to initialize.</param>
     public override void Initialize(AnalysisContext context)
     {
+        Debug.Assert(context != null, nameof(context) + " != null");
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
         context.RegisterSymbolAction(AnalyzeMethodSymbol, SymbolKind.Method);
     }
 
+    /// <summary>
+    ///     Analyzes a method symbol to verify proper usage of DataPoint and TestCase attributes.
+    /// </summary>
+    /// <param name="context">The symbol analysis context containing the method to analyze.</param>
     private static void AnalyzeMethodSymbol(SymbolAnalysisContext context)
     {
         var methodSymbol = (IMethodSymbol)context.Symbol;
@@ -35,7 +55,8 @@ public class DataPointAttributeAnalyzer : DiagnosticAnalyzer
         var hasDataPoint = methodSymbol.GetAttributes()
             .Any(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, dataPointAttr));
 
-        if (!hasDataPoint) return;
+        if (!hasDataPoint)
+            return;
 
         // Get all TestCase attributes with their ApplicationSyntaxReference
         var testCaseAttributes = methodSymbol.GetAttributes()
@@ -44,6 +65,7 @@ public class DataPointAttributeAnalyzer : DiagnosticAnalyzer
 
         // Report on all TestCase attributes after the first one
         foreach (var testCaseAttribute in testCaseAttributes)
+        {
             if (testCaseAttribute.ApplicationSyntaxReference?.GetSyntax() is { } syntaxNode)
             {
                 var diagnostic = Diagnostic.Create(
@@ -52,5 +74,6 @@ public class DataPointAttributeAnalyzer : DiagnosticAnalyzer
                     methodSymbol.Name);
                 context.ReportDiagnostic(diagnostic);
             }
+        }
     }
 }

--- a/Analyzers/src/DiagnosticRules.cs
+++ b/Analyzers/src/DiagnosticRules.cs
@@ -1,33 +1,53 @@
-﻿namespace GdUnit4.Analyzers;
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+namespace GdUnit4.Analyzers;
 
 using Microsoft.CodeAnalysis;
 
+/// <summary>
+///     Provides diagnostic descriptors for GdUnit4 analyzer rules.
+///     These rules help enforce the correct usage of GdUnit4 test attributes
+///     and identify potential issues during compilation time.
+/// </summary>
 internal static class DiagnosticRules
 {
     private const string HELP_LINK = "https://github.com/MikeSchulze/gdUnit4Net/tree/master/Analyzers/documentation";
 
-    // Rule identifiers - makes it easier to track and maintain rule IDs
+    /// <summary>
+    ///     Contains the identifiers for GdUnit4 analyzer rules.
+    /// </summary>
     internal static class RuleIds
     {
         // Rule IDs (GdUnit01xx)
         // public const string TestCaseName = "GdUnit0101";
 
-        // Datapoint rules starting at 0200
+        /// <summary>
+        ///     Rule ID for detecting when a method with a DataPoint attribute has multiple TestCase attributes.
+        /// </summary>
         public const string DataPointWithMultipleTestCase = "GdUnit0201";
 
-        // Godot runtime detection rules at 500
+        /// <summary>
+        ///     Rule ID for detecting when a test class using Godot functionality needs the RequireGodotRuntime attribute.
+        /// </summary>
         public const string RequiresGodotRuntimeOnClassId = "GdUnit0500";
+
+        /// <summary>
+        ///     Rule ID for detecting when a test method using Godot functionality needs the RequireGodotRuntime attribute.
+        /// </summary>
         public const string RequiresGodotRuntimeOnMethodId = "GdUnit0501";
     }
 
-
-    private static class Categories
-    {
-        public const string AttributeUsage = "Attribute Usage";
-    }
-
+    /// <summary>
+    ///     Provides diagnostic descriptors for DataPoint-related rules.
+    ///     These rules ensure proper usage of DataPoint attributes in test methods.
+    /// </summary>
     internal static class DataPoint
     {
+        /// <summary>
+        ///     Diagnostic rule for detecting when a method with a DataPoint attribute has multiple TestCase attributes.
+        ///     DataPoint methods should only have a single TestCase attribute to avoid undefined behavior.
+        /// </summary>
         public static readonly DiagnosticDescriptor MultipleTestCaseAttributes = new(
             RuleIds.DataPointWithMultipleTestCase,
             "Multiple TestCase attributes not allowed with DataPoint",
@@ -42,8 +62,16 @@ internal static class DiagnosticRules
         // Future TestCase rules can be added here
     }
 
+    /// <summary>
+    ///     Provides diagnostic descriptors for Godot runtime requirement rules.
+    ///     These rules ensure that tests using Godot functionality are properly annotated.
+    /// </summary>
     internal static class GodotEngine
     {
+        /// <summary>
+        ///     Diagnostic rule for detecting when a test method using Godot functionality
+        ///     is missing the RequireGodotRuntime attribute.
+        /// </summary>
         public static readonly DiagnosticDescriptor RequiresGodotRuntimeOnMethod = new(
             RuleIds.RequiresGodotRuntimeOnMethodId,
             "Godot Runtime Required for Test Method",
@@ -61,6 +89,10 @@ internal static class DiagnosticRules
             $"{HELP_LINK}/{RuleIds.RequiresGodotRuntimeOnMethodId}.md",
             WellKnownDiagnosticTags.Compiler);
 
+        /// <summary>
+        ///     Diagnostic rule for detecting when a test class with hooks using Godot functionality
+        ///     is missing the RequireGodotRuntime attribute.
+        /// </summary>
         public static readonly DiagnosticDescriptor RequiresGodotRuntimeOnClass = new(
             RuleIds.RequiresGodotRuntimeOnClassId,
             "Godot Runtime Required for Test Class",
@@ -77,5 +109,17 @@ internal static class DiagnosticRules
             """,
             $"{HELP_LINK}/{RuleIds.RequiresGodotRuntimeOnClassId}.md",
             WellKnownDiagnosticTags.Compiler);
+    }
+
+    /// <summary>
+    ///     Defines diagnostic categories used for grouping rules.
+    ///     These categories help organize rules by their purpose or area of concern.
+    /// </summary>
+    private static class Categories
+    {
+        /// <summary>
+        ///     Category for rules related to proper usage of attributes.
+        /// </summary>
+        public const string AttributeUsage = "Attribute Usage";
     }
 }

--- a/Analyzers/src/GodotRuntimeRequireAnalyzer.cs
+++ b/Analyzers/src/GodotRuntimeRequireAnalyzer.cs
@@ -1,10 +1,13 @@
-﻿#nullable enable
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
 namespace GdUnit4.Analyzers;
 
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
@@ -18,17 +21,67 @@ using static DiagnosticRules;
 ///     Analyzer that enforces proper Godot runtime requirements for test classes and methods.
 /// </summary>
 /// <remarks>
-///     This analyzer checks for two scenarios:
-///     <list type="bullet">
-///         <item>Test methods using Godot types must use [GodotTestCase] instead of [TestCase]</item>
-///         <item>Test classes with Godot dependencies in hooks must use [RequireGodotRuntime]</item>
-///     </list>
+///     <para>
+///         This analyzer ensures that tests using Godot functionality are properly annotated with the
+///         appropriate attributes. It performs static code analysis to detect Godot dependencies
+///         and verifies they have the correct runtime context.
+///     </para>
+///     <para>
+///         The analyzer checks for two main scenarios:
+///         <list type="bullet">
+///             <item>
+///                 <description>
+///                     Test methods using Godot types must be annotated with [RequireGodotRuntime]
+///                     to ensure they execute within the Godot runtime environment.
+///                 </description>
+///             </item>
+///             <item>
+///                 <description>
+///                     Test classes with Godot dependencies in their test hook methods (like [Before] or [After])
+///                     must be annotated with [RequireGodotRuntime] at the class level.
+///                 </description>
+///             </item>
+///         </list>
+///     </para>
+///     <para>
+///         The analyzer performs deep dependency analysis by:
+///         <list type="bullet">
+///             <item>Examining method signatures for Godot types</item>
+///             <item>Analyzing method body operations for Godot dependencies</item>
+///             <item>Following method calls to detect transitive Godot dependencies</item>
+///             <item>Checking field and property references for Godot types</item>
+///         </list>
+///     </para>
+///     <para>
+///         When a violation is detected, appropriate diagnostics are reported to guide the developer
+///         on how to fix the issue by adding the required runtime attribute.
+///     </para>
 /// </remarks>
+/// <example>
+///     <code>
+///     // This test method uses Godot types but is missing [RequireGodotRuntime]
+///     [TestCase]
+///     public void TestSceneLoading()
+///     {
+///         var scene = new Godot.PackedScene(); // Will trigger diagnostic
+///         // ...
+///     }
+///
+///     // Correct usage:
+///     [TestCase]
+///     [RequireGodotRuntime]
+///     public void TestSceneLoading()
+///     {
+///         var scene = new Godot.PackedScene(); // No diagnostic
+///         // ...
+///     }
+///     </code>
+/// </example>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class GodotRuntimeRequireAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly string RequireGodotRuntimeAttribute = "GdUnit4.RequireGodotRuntimeAttribute";
-    private static readonly string TestCaseAttribute = "GdUnit4.TestCaseAttribute";
+    private const string REQUIRE_GODOT_RUNTIME_ATTRIBUTE = "GdUnit4.RequireGodotRuntimeAttribute";
+    private const string TEST_CASE_ATTRIBUTE = "GdUnit4.TestCaseAttribute";
     private static readonly string[] TestHookAttributes = { "GdUnit4.BeforeAttribute", "GdUnit4.AfterAttribute", "GdUnit4.BeforeTestAttribute", "GdUnit4.AfterTestAttribute" };
 
     private static readonly ConcurrentDictionary<string, bool> GodotTypeCache = new();
@@ -36,18 +89,25 @@ public class GodotRuntimeRequireAnalyzer : DiagnosticAnalyzer
     private static readonly HashSet<string> GodotDependentTypes = new()
     {
         "GdUnit4.ISceneRunner"
+
         // Add any other GdUnit4 types that require Godot runtime
     };
 
-
+    /// <summary>
+    ///     Gets the supported diagnostics.
+    /// </summary>
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(
             GodotEngine.RequiresGodotRuntimeOnClass,
-            GodotEngine.RequiresGodotRuntimeOnMethod
-        );
+            GodotEngine.RequiresGodotRuntimeOnMethod);
 
+    /// <summary>
+    ///     Initializes the analyzer with the analysis context.
+    /// </summary>
+    /// <param name="context">The analysis context to initialize.</param>
     public override void Initialize(AnalysisContext context)
     {
+        Debug.Assert(context != null, nameof(context) + " != null");
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
         context.RegisterOperationAction(AnalyzeTestMethod, OperationKind.MethodBody);
@@ -78,7 +138,9 @@ public class GodotRuntimeRequireAnalyzer : DiagnosticAnalyzer
 
             ReportMethodDiagnostic(context, methodSymbol);
         }
+#pragma warning disable CA1031
         catch (Exception e)
+#pragma warning restore CA1031
         {
             Console.WriteLine(e);
         }
@@ -94,8 +156,7 @@ public class GodotRuntimeRequireAnalyzer : DiagnosticAnalyzer
         {
             if (context.Operation is not IMethodBodyOperation methodBody)
                 return;
-            var methodSymbol = methodBody.SemanticModel?.GetDeclaredSymbol(methodBody.Syntax) as IMethodSymbol;
-            if (methodSymbol == null)
+            if (methodBody.SemanticModel?.GetDeclaredSymbol(methodBody.Syntax) is not IMethodSymbol methodSymbol)
                 return;
 
             // Skip analysis if class has RequireGodotRuntime attribute
@@ -110,7 +171,9 @@ public class GodotRuntimeRequireAnalyzer : DiagnosticAnalyzer
 
             ReportClassDiagnostic(context, methodSymbol.ContainingType);
         }
+#pragma warning disable CA1031
         catch (Exception e)
+#pragma warning restore CA1031
         {
             Console.WriteLine(e);
         }
@@ -134,24 +197,23 @@ public class GodotRuntimeRequireAnalyzer : DiagnosticAnalyzer
         context.ReportDiagnostic(diagnostic);
     }
 
-
     private static bool IsTestHook(IMethodSymbol method)
         => method.GetAttributes()
             .Any(attr => TestHookAttributes.Contains(attr.AttributeClass?.ToDisplayString()));
 
     private static bool HasGodotRuntimeAttributeAtClassLevel(INamedTypeSymbol classSymbol)
         => classSymbol.GetAttributes()
-            .Any(attr => attr.AttributeClass?.ToDisplayString() == RequireGodotRuntimeAttribute);
+            .Any(attr => attr.AttributeClass?.ToDisplayString() == REQUIRE_GODOT_RUNTIME_ATTRIBUTE);
 
     private static bool HasGodotRuntimeAttributeAtMethodLevel(IMethodSymbol methodSymbol)
         => methodSymbol.GetAttributes()
-            .Any(attr => attr.AttributeClass?.ToDisplayString() == RequireGodotRuntimeAttribute);
+            .Any(attr => attr.AttributeClass?.ToDisplayString() == REQUIRE_GODOT_RUNTIME_ATTRIBUTE);
 
     private static bool HasTestCaseAttribute(IMethodSymbol methodSymbol)
         => methodSymbol.GetAttributes()
-            .Any(attr => attr.AttributeClass?.ToDisplayString() == TestCaseAttribute);
+            .Any(attr => attr.AttributeClass?.ToDisplayString() == TEST_CASE_ATTRIBUTE);
 
-    private static bool ContainsGodotTypes(IMethodSymbol method, Compilation compilation, SemanticModel semanticModel, HashSet<IMethodSymbol>? visitedMethods = null)
+    private static bool ContainsGodotTypes(IMethodSymbol method, Compilation compilation, SemanticModel semanticModel, HashSet<IMethodSymbol> visitedMethods = null)
     {
         visitedMethods ??= new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
         if (!visitedMethods.Add(method))
@@ -199,6 +261,7 @@ public class GodotRuntimeRequireAnalyzer : DiagnosticAnalyzer
             return false;
 
         foreach (var operation in methodOperation.Descendants())
+        {
             switch (operation)
             {
                 case IFieldReferenceOperation fieldRef:
@@ -210,7 +273,11 @@ public class GodotRuntimeRequireAnalyzer : DiagnosticAnalyzer
                     if (InheritsFromGodotType(propRef.Property.Type))
                         return true;
                     break;
+                default:
+                    // Other operation types should be handled if they become relevant for Godot type detection
+                    throw new NotImplementedException($"Operation type {operation.GetType().Name} is not handled!");
             }
+        }
 
         return false;
     }
@@ -231,12 +298,13 @@ public class GodotRuntimeRequireAnalyzer : DiagnosticAnalyzer
         return fieldOperation != null && ContainsGodotTypesInOperationTree(fieldOperation, semanticModel.Compilation, null);
     }
 
-    private static IOperation? GetMethodOperationTree(SyntaxReference syntaxRef, Compilation compilation, SemanticModel semanticModel)
+#pragma warning disable IDE0060
+    private static IOperation GetMethodOperationTree(SyntaxReference syntaxRef, Compilation compilation, SemanticModel semanticModel)
+#pragma warning restore IDE0060
     {
         var methodSyntax = syntaxRef.GetSyntax() as MethodDeclarationSyntax;
         if (methodSyntax?.Body == null && methodSyntax?.ExpressionBody == null)
             return null;
-
 
         return semanticModel.GetOperation(methodSyntax);
         /*
@@ -251,7 +319,7 @@ public class GodotRuntimeRequireAnalyzer : DiagnosticAnalyzer
         }*/
     }
 
-    private static bool ContainsGodotTypesInOperationTree(IOperation operation, Compilation compilation, HashSet<IMethodSymbol>? visitedMethods)
+    private static bool ContainsGodotTypesInOperationTree(IOperation operation, Compilation compilation, HashSet<IMethodSymbol> visitedMethods)
     {
         // Collect all relevant operations first
         var operations = operation.Descendants()
@@ -259,13 +327,15 @@ public class GodotRuntimeRequireAnalyzer : DiagnosticAnalyzer
             .ToList();
 
         foreach (var op in operations)
+        {
             if (AnalyzeOperationNode(op, compilation, visitedMethods))
                 return true;
+        }
+
         return false;
     }
 
-
-    private static bool AnalyzeOperationNode(IOperation operation, Compilation compilation, HashSet<IMethodSymbol>? visitedMethods)
+    private static bool AnalyzeOperationNode(IOperation operation, Compilation compilation, HashSet<IMethodSymbol> visitedMethods)
         => operation switch
         {
             ILocalReferenceOperation local => AnalyzeLocalReference(local),
@@ -285,7 +355,7 @@ public class GodotRuntimeRequireAnalyzer : DiagnosticAnalyzer
     private static bool AnalyzeObjectCreation(IObjectCreationOperation creation) =>
         InheritsFromGodotType(creation.Type);
 
-    private static bool AnalyzeMethodCall(IInvocationOperation invocation, Compilation compilation, HashSet<IMethodSymbol>? visitedMethods)
+    private static bool AnalyzeMethodCall(IInvocationOperation invocation, Compilation compilation, HashSet<IMethodSymbol> visitedMethods)
     {
         // First check the direct Godot usage
         if (InheritsFromGodotType(invocation.Type))
@@ -307,7 +377,9 @@ public class GodotRuntimeRequireAnalyzer : DiagnosticAnalyzer
             // analysis of internal methods
             return ContainsGodotTypes(invocation.TargetMethod, compilation, invocation.SemanticModel!);
         }
+#pragma warning disable CA1031
         catch (Exception e)
+#pragma warning restore CA1031
         {
             Console.WriteLine(e);
         }
@@ -316,22 +388,19 @@ public class GodotRuntimeRequireAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-
-    private static bool AnalyzeExternalMethod(IMethodSymbol method, HashSet<IMethodSymbol>? visitedMethods = null)
+    private static bool AnalyzeExternalMethod(IMethodSymbol method, HashSet<IMethodSymbol> visitedMethods = null)
     {
         // do not analyze standard .net methods
         var ns = method.ToDisplayString();
-        if (ns.StartsWith("System") ||
-            ns.StartsWith("Microsoft") ||
-            ns == "global" ||
-            ns == "<global namespace>")
+        if (ns.StartsWith("System")
+            || ns.StartsWith("Microsoft")
+            || ns == "global"
+            || ns == "<global namespace>")
             return false;
-
 
         visitedMethods ??= new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
         if (!visitedMethods.Add(method))
             return false;
-
 
         // Check method attributes
         if (method.GetAttributes().Any(attr => InheritsFromGodotType(attr.AttributeClass)))
@@ -345,10 +414,8 @@ public class GodotRuntimeRequireAnalyzer : DiagnosticAnalyzer
         if (method.Parameters.Any(p => InheritsFromGodotType(p.Type)))
             return true;
 
-
         return false;
     }
-
 
     private static bool AnalyzePropertyAccessOperation(IPropertyReferenceOperation property)
     {
@@ -384,12 +451,13 @@ public class GodotRuntimeRequireAnalyzer : DiagnosticAnalyzer
     private static bool AnalyzeTypeOf(ITypeOfOperation typeOf) =>
         InheritsFromGodotType(typeOf.TypeOperand);
 
-    private static bool InheritsFromGodotType(ITypeSymbol? type)
+    private static bool InheritsFromGodotType(ITypeSymbol type)
     {
         if (type == null)
             return false;
 
         var typeName = type.ToDisplayString();
+
         // Check for GdUnit4 types that require Godot
         if (GodotDependentTypes.Contains(typeName))
             return true;
@@ -400,14 +468,16 @@ public class GodotRuntimeRequireAnalyzer : DiagnosticAnalyzer
             while (current != null)
             {
                 var ns = current.ContainingNamespace?.ToDisplayString();
+
                 // Early exits for common namespace patterns
                 if (ns == null)
                     return false;
+
                 // Known non-Godot namespaces
-                if (ns.StartsWith("System") ||
-                    ns.StartsWith("Microsoft") ||
-                    ns == "global" ||
-                    ns == "<global namespace>")
+                if (ns.StartsWith("System")
+                    || ns.StartsWith("Microsoft")
+                    || ns == "global"
+                    || ns == "<global namespace>")
                     return false;
                 if (ns.StartsWith("Godot"))
                     return true;

--- a/Analyzers/src/UtilsX3.cs
+++ b/Analyzers/src/UtilsX3.cs
@@ -1,6 +1,0 @@
-﻿namespace GdUnit4.Analyzers;
-
-public static class UtilsX3
-{
-    public static string Foo() => "";
-}

--- a/stylecop.json
+++ b/stylecop.json
@@ -1,0 +1,12 @@
+﻿{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "companyName": "Mike Schulze",
+      "copyrightText": "Copyright (c) 2025 Mike Schulze\nMIT License - See LICENSE file in the repository root for full license text",
+      "xmlHeader": false,
+      "headerDecoration": "",
+      "fileNamingConvention": "stylecop"
+    }
+  }
+}

--- a/stylecop.ruleset
+++ b/stylecop.ruleset
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Custom Ruleset" Description="Custom Ruleset" ToolsVersion="16.0">
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+    <Rule Id="IDE0011" Action="None"/>
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1503" Action="None"/>
+  </Rules>
+</RuleSet>


### PR DESCRIPTION
# Why
Consistent code style improves readability and maintainability across the codebase.

# What
- Configure style enforcement using .editorconfig for general formatting rules
- Implement StyleCop analyzers via NuGet package for additional code style checks
- Set up custom ruleset to control analyzer behavior and severity levels
- Override specific rule configurations in Directory.Build.props for project-wide settings