### PR TITLE
GD-212: Fix vector assertion `IsEqualApprox`

### DIFF
--- a/Api/src/Assertions.cs
+++ b/Api/src/Assertions.cs
@@ -181,6 +181,15 @@ public static class Assertions
     public static IVectorAssert<Vector4> AssertThat(Vector4 current) => new VectorAssert<Vector4>(current);
     public static IVectorAssert<Vector4I> AssertThat(Vector4I current) => new VectorAssert<Vector4I>(current);
 
+    public static IVectorAssert<System.Numerics.Vector2> AssertThat(System.Numerics.Vector2 current)
+        => new VectorAssert<System.Numerics.Vector2>(current);
+
+    public static IVectorAssert<System.Numerics.Vector3> AssertThat(System.Numerics.Vector3 current)
+        => new VectorAssert<System.Numerics.Vector3>(current);
+
+    public static IVectorAssert<System.Numerics.Vector4> AssertThat(System.Numerics.Vector4 current)
+        => new VectorAssert<System.Numerics.Vector4>(current);
+
     /// <summary>
     ///     A dynamic assertion for <see cref="Godot.Variant" /> based on the input type.
     /// </summary>

--- a/Api/src/asserts/VectorAssert.cs
+++ b/Api/src/asserts/VectorAssert.cs
@@ -3,7 +3,13 @@ namespace GdUnit4.Asserts;
 using System;
 using System.Globalization;
 
+using Core.Extensions;
+
 using Godot;
+
+using SystemVector2 = System.Numerics.Vector2;
+using SystemVector3 = System.Numerics.Vector3;
+using SystemVector4 = System.Numerics.Vector4;
 
 public class VectorAssert<TValue> : AssertBase<TValue>, IVectorAssert<TValue> where TValue : IEquatable<TValue>
 {
@@ -23,7 +29,23 @@ public class VectorAssert<TValue> : AssertBase<TValue>, IVectorAssert<TValue> wh
     public IVectorAssert<TValue> IsEqualApprox(TValue expected, TValue approx)
     {
         var minMax = MinMax(expected, approx);
-        return IsBetween(minMax.Item1, minMax.Item2);
+        var isEqualApproximate = (Current, expected, approx) switch
+        {
+            (SystemVector2 v, SystemVector2 e, SystemVector2 a) => v.IsEqualApprox(e, a),
+            (SystemVector3 v, SystemVector3 e, SystemVector3 a) => v.IsEqualApprox(e, a),
+            (SystemVector4 v, SystemVector4 e, SystemVector4 a) => v.IsEqualApprox(e, a),
+            (Vector2 v, Vector2 e, Vector2 a) => v.IsEqualApprox(e, a),
+            (Vector2I v, Vector2I e, Vector2I a) => v.IsEqualApprox(e, a),
+            (Vector3 v, Vector3 e, Vector3 a) => v.IsEqualApprox(e, a),
+            (Vector3I v, Vector3I e, Vector3I a) => v.IsEqualApprox(e, a),
+            (Vector4 v, Vector4 e, Vector4 a) => v.IsEqualApprox(e, a),
+            (Vector4I v, Vector4I e, Vector4I a) => v.IsEqualApprox(e, a),
+            _ => false
+        };
+        if (!isEqualApproximate)
+            ThrowTestFailureReport(AssertFailures.IsBetween(Current, minMax.Item1, minMax.Item2), Current, minMax.Item1);
+
+        return this;
     }
 
     public IVectorAssert<TValue> IsGreater(TValue expected)
@@ -84,6 +106,12 @@ public class VectorAssert<TValue> : AssertBase<TValue>, IVectorAssert<TValue> wh
 #pragma warning disable CS8619
     private static (TValue, TValue) MinMax(TValue left, TValue right) => (left, right) switch
     {
+        (SystemVector2 l, SystemVector2 r) => ((TValue)Convert.ChangeType(l - r, typeof(TValue), CultureInfo.InvariantCulture),
+            (TValue)Convert.ChangeType(l + r, typeof(TValue), CultureInfo.InvariantCulture)),
+        (SystemVector3 l, SystemVector3 r) => ((TValue)Convert.ChangeType(l - r, typeof(TValue), CultureInfo.InvariantCulture),
+            (TValue)Convert.ChangeType(l + r, typeof(TValue), CultureInfo.InvariantCulture)),
+        (SystemVector4 l, SystemVector4 r) => ((TValue)Convert.ChangeType(l - r, typeof(TValue), CultureInfo.InvariantCulture),
+            (TValue)Convert.ChangeType(l + r, typeof(TValue), CultureInfo.InvariantCulture)),
         (Vector2 l, Vector2 r) => ((TValue)Convert.ChangeType(l - r, typeof(TValue), CultureInfo.InvariantCulture),
             (TValue)Convert.ChangeType(l + r, typeof(TValue), CultureInfo.InvariantCulture)),
         (Vector2I l, Vector2I r) => ((TValue)Convert.ChangeType(l - r, typeof(TValue), CultureInfo.InvariantCulture),

--- a/Api/src/core/extensions/GodotVectorExtension.cs
+++ b/Api/src/core/extensions/GodotVectorExtension.cs
@@ -1,0 +1,66 @@
+﻿namespace GdUnit4.Core.Extensions;
+
+using Godot;
+
+public static class GodotVectorExtension
+{
+    internal static bool IsEqualApprox(this Vector2 vector, Vector2 other, Vector2 approx)
+    {
+        var min = other - approx;
+        var max = other + approx;
+
+        var r1 = vector.X >= min.X && vector.Y >= min.Y;
+        var r2 = vector.X <= max.X && vector.Y <= max.Y;
+        return r1 && r2;
+    }
+
+    internal static bool IsEqualApprox(this Vector2I vector, Vector2I other, Vector2I approx)
+    {
+        var min = other - approx;
+        var max = other + approx;
+
+        var r1 = vector.X >= min.X && vector.Y >= min.Y;
+        var r2 = vector.X <= max.X && vector.Y <= max.Y;
+        return r1 && r2;
+    }
+
+    internal static bool IsEqualApprox(this Vector3 vector, Vector3 other, Vector3 approx)
+    {
+        var min = other - approx;
+        var max = other + approx;
+
+        var r1 = vector.X >= min.X && vector.Y >= min.Y && vector.Z >= min.Z;
+        var r2 = vector.X <= max.X && vector.Y <= max.Y && vector.Z <= max.Z;
+        return r1 && r2;
+    }
+
+    internal static bool IsEqualApprox(this Vector3I vector, Vector3I other, Vector3I approx)
+    {
+        var min = other - approx;
+        var max = other + approx;
+
+        var r1 = vector.X >= min.X && vector.Y >= min.Y && vector.Z >= min.Z;
+        var r2 = vector.X <= max.X && vector.Y <= max.Y && vector.Z <= max.Z;
+        return r1 && r2;
+    }
+
+    internal static bool IsEqualApprox(this Vector4 vector, Vector4 other, Vector4 approx)
+    {
+        var min = other - approx;
+        var max = other + approx;
+
+        var r1 = vector.X >= min.X && vector.Y >= min.Y && vector.Z >= min.Z && vector.W >= min.W;
+        var r2 = vector.X <= max.X && vector.Y <= max.Y && vector.Z <= max.Z && vector.W <= max.W;
+        return r1 && r2;
+    }
+
+    internal static bool IsEqualApprox(this Vector4I vector, Vector4I other, Vector4I approx)
+    {
+        var min = other - approx;
+        var max = other + approx;
+
+        var r1 = vector.X >= min.X && vector.Y >= min.Y && vector.Z >= min.Z && vector.W >= min.W;
+        var r2 = vector.X <= max.X && vector.Y <= max.Y && vector.Z <= max.Z && vector.W <= max.W;
+        return r1 && r2;
+    }
+}

--- a/Api/src/core/extensions/SystemVectorExtension.cs
+++ b/Api/src/core/extensions/SystemVectorExtension.cs
@@ -1,0 +1,38 @@
+﻿namespace GdUnit4.Core.Extensions;
+
+using SystemVector2 = System.Numerics.Vector2;
+using SystemVector3 = System.Numerics.Vector3;
+using SystemVector4 = System.Numerics.Vector4;
+
+public static class SystemVectorExtension
+{
+    internal static bool IsEqualApprox(this SystemVector2 vector, SystemVector2 other, SystemVector2 approx)
+    {
+        var min = other - approx;
+        var max = other + approx;
+
+        var r1 = vector.X >= min.X && vector.Y >= min.Y;
+        var r2 = vector.X <= max.X && vector.Y <= max.Y;
+        return r1 && r2;
+    }
+
+    internal static bool IsEqualApprox(this SystemVector3 vector, SystemVector3 other, SystemVector3 approx)
+    {
+        var min = other - approx;
+        var max = other + approx;
+
+        var r1 = vector.X >= min.X && vector.Y >= min.Y && vector.Z >= min.Z;
+        var r2 = vector.X <= max.X && vector.Y <= max.Y && vector.Z <= max.Z;
+        return r1 && r2;
+    }
+
+    internal static bool IsEqualApprox(this SystemVector4 vector, SystemVector4 other, SystemVector4 approx)
+    {
+        var min = other - approx;
+        var max = other + approx;
+
+        var r1 = vector.X >= min.X && vector.Y >= min.Y && vector.Z >= min.Z && vector.W >= min.W;
+        var r2 = vector.X <= max.X && vector.Y <= max.Y && vector.Z <= max.Z && vector.W <= max.W;
+        return r1 && r2;
+    }
+}


### PR DESCRIPTION
# Why
Vector `IsEqualApprox` returns true even though vectors are not approximately equal

# What
Reimplement `IsEqualApprox` and add more test coverage.