### PR TITLE
GD-240: Add `GDUNIT4NET_API_V5` Conditional Compilation Constant

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -194,7 +194,7 @@ jobs:
 
           validate_section '<Output>' 'Discover tests done, 2 TestSuites and total 15 Tests found.'
           validate_section '<Results>' "<Message>Expecting: 'True' but is 'False'</Message>"
-          validate_section '<Results>' '<StackTrace>   at Examples.ExampleTest.Failed() in /home/runner/work/gdUnit4Net/gdUnit4Net/Example/test/ExampleTest.cs:line 18'
+          validate_section '<Results>' '<StackTrace>   at Examples.ExampleTest.Failed() in /home/runner/work/gdUnit4Net/gdUnit4Net/Example/test/ExampleTest.cs:line 19'
           validate_section '<ResultSummary' '<ResultSummary outcome="Failed">'
           validate_section '<ResultSummary' '<Counters total="19" executed="19" passed="18" failed="1" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />'
           echo "All tests passes."

--- a/Api/GdUnit4Api.csproj
+++ b/Api/GdUnit4Api.csproj
@@ -62,6 +62,8 @@
     <None Include="../LICENSE" Pack="true" PackagePath="/"/>
     <None Include="../CONTRIBUTING.md" Pack="true" PackagePath="/"/>
     <None Include="../icon.png" Pack="true" PackagePath="/"/>
+    <None Include="build/gdUnit4.api.props" Pack="true" PackagePath="build/gdUnit4.api.props"/>
+    <None Include="buildTransitive/gdUnit4.api.props" Pack="true" PackagePath="buildTransitive/gdUnit4.api.props"/>
 
     <!-- provide the test runner scene as resource -->
     <EmbeddedResource Include="src\core\runners\GdUnit4TestRunnerSceneTemplate.cs"/>

--- a/Api/build/gdUnit4.api.props
+++ b/Api/build/gdUnit4.api.props
@@ -1,0 +1,6 @@
+﻿<!-- Create: build/gdUnit4.api.props -->
+<Project>
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);GDUNIT4NET_API_V5</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/Api/buildTransitive/gdUnit4.api.props
+++ b/Api/buildTransitive/gdUnit4.api.props
@@ -1,0 +1,5 @@
+﻿<Project>
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);GDUNIT4NET_API_V5</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/Example/ExampleProject.csproj
+++ b/Example/ExampleProject.csproj
@@ -20,7 +20,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftSdkVersion)"/>
         <!-- We only include here the MSTest framework to run tests mixed with MSTest assertions, but set it to private to prevent conflicts -->
         <PackageReference Include="MSTest.TestFramework" Version="3.0.2" ExcludeAssets="build;analyzers;native"/>
-        <PackageReference Include="gdUnit4.api" Version="5.0.0-rc2"/>
+        <PackageReference Include="gdUnit4.api" Version="5.0.0-rc3"/>
         <PackageReference Include="gdUnit4.test.adapter" Version="3.0.0-rc1"/>
         <PackageReference Include="gdUnit4.analyzers" Version="1.0.0-rc7">
             <PrivateAssets>none</PrivateAssets>

--- a/Example/test/ExampleTest.cs
+++ b/Example/test/ExampleTest.cs
@@ -1,5 +1,6 @@
 namespace Examples;
 
+#if GDUNIT4NET_API_V5
 using GdUnit4;
 
 using static GdUnit4.Assertions;
@@ -30,3 +31,4 @@ public class ExampleTest
     [TestCase(1, 2, 3, TestName = "TestB", Description = "foo ")]
     public void DataRows(int a, int b, int c) => AssertBool(true).IsTrue();
 }
+#endif

--- a/PackageVersions.props
+++ b/PackageVersions.props
@@ -6,7 +6,7 @@
     <MicrosoftCodeAnalysisCSharpVersion>4.9.2</MicrosoftCodeAnalysisCSharpVersion>
     <MoqVersion>4.18.4</MoqVersion>
     <GdUnitAnalyzersVersion>1.0.0-rc7</GdUnitAnalyzersVersion>
-    <GdUnitAPIVersion>5.0.0-rc2</GdUnitAPIVersion>
+    <GdUnitAPIVersion>5.0.0-rc3</GdUnitAPIVersion>
     <GdUnitTestAdapterVersion>3.0.0-rc1</GdUnitTestAdapterVersion>
   </PropertyGroup>
 </Project>

--- a/TestAdapter.Test/test/discovery/GdUnit4TestDiscovererTest.cs
+++ b/TestAdapter.Test/test/discovery/GdUnit4TestDiscovererTest.cs
@@ -171,7 +171,7 @@ public class GdUnit4TestDiscovererTest
             "Success",
             assemblyPath,
             @"Example\test\ExampleTest.cs",
-            14);
+            15);
 
         // multi testcase attribute usage
         AssertTestCase(
@@ -180,14 +180,14 @@ public class GdUnit4TestDiscovererTest
             "TestA:0 (0, 1, 2)",
             assemblyPath,
             @"Example\test\ExampleTest.cs",
-            31);
+            32);
         AssertTestCase(
             discoveredTests,
             "Examples.ExampleTest.DataRows.TestB:1 (1, 2, 3)",
             "TestB:1 (1, 2, 3)",
             assemblyPath,
             @"Example\test\ExampleTest.cs",
-            31);
+            32);
     }
 
     private static bool IsAssemblyLoaded(string assemblyPath)


### PR DESCRIPTION
# Why
Add automatic conditional compilation support to enable optional GdUnit4 API usage in projects through the GDUNIT4NET_API_V5 constant.

# What
- Add Compilation Constant `GDUNIT4NET_API_V5`