### PR TITLE
Upgrade to .NET 8/9 with C# 12 support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -122,7 +122,7 @@ dotnet_separate_import_directive_groups = true
 dotnet_style_predefined_type_for_locals_parameters_members = true : warning
 dotnet_style_predefined_type_for_member_access = true : warning
 # Modifier preferences
-dotnet_style_require_accessibility_modifiers = always : warning
+dotnet_style_require_accessibility_modifiers = for_non_interface_members : warning
 csharp_preferred_modifier_order = public, private, protected, internal, required, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async : warning
 visual_basic_preferred_modifier_order = Partial, Default, Private, Protected, Public, Friend, NotOverridable, Overridable, MustOverride, Overloads, Overrides, MustInherit, NotInheritable, Static, Shared, Shadows, ReadOnly, WriteOnly, Dim, Const, WithEvents, Widening, Narrowing, Custom, Async : warning
 dotnet_style_readonly_field = true : warning

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -48,6 +48,20 @@ jobs:
         with:
           lfs: true
 
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: 'global.json'
+
+      - name: "Restore Build Cache"
+        if: ${{ !cancelled() }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            **/obj
+            **/bin
+            **/nupkg
+          key: ${{ runner.os }}-build-${{ github.sha }}-${{ github.run_id }}
+
       # the vstest filter is actual not implemented and the argument 'paths' on gdUnit4-action@v1.0.8 will have no affect
       - name: 'Temp solution, we delete the failing test for now.'
         shell: bash

--- a/Analyzers.Test/src/VerifyDocumentationTest.cs
+++ b/Analyzers.Test/src/VerifyDocumentationTest.cs
@@ -87,7 +87,7 @@ public partial class VerifyDocumentationTest
         foreach (var field in dataPointType.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy))
         {
             if (field.FieldType == typeof(DiagnosticDescriptor) && field.IsInitOnly)
-                yield return ((DiagnosticDescriptor)field.GetValue(null), field.Name.Replace("Attribute", string.Empty, StringComparison.Ordinal));
+                yield return ((DiagnosticDescriptor)field.GetValue(null)!, field.Name.Replace("Attribute", string.Empty, StringComparison.Ordinal));
         }
 
         // Get GodotEngine diagnostics
@@ -95,7 +95,7 @@ public partial class VerifyDocumentationTest
         foreach (var field in godotEngineType.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy))
         {
             if (field.FieldType == typeof(DiagnosticDescriptor) && field.IsInitOnly)
-                yield return ((DiagnosticDescriptor)field.GetValue(null), field.Name);
+                yield return ((DiagnosticDescriptor)field.GetValue(null)!, field.Name);
         }
     }
 
@@ -109,12 +109,13 @@ public partial class VerifyDocumentationTest
             var match = rowRegex.Match(line);
             if (match.Success)
             {
-                tableRows.Add(new DiagnosticRuleTableRecord
-                {
-                    Id = match.Groups[1].Value.Trim(),
-                    Severity = match.Groups[2].Value.Trim(),
-                    Title = match.Groups[3].Value.Trim()
-                });
+                tableRows.Add(
+                    new DiagnosticRuleTableRecord
+                    {
+                        Id = match.Groups[1].Value.Trim(),
+                        Severity = match.Groups[2].Value.Trim(),
+                        Title = match.Groups[3].Value.Trim()
+                    });
             }
         }
 

--- a/Analyzers.Test/test.ruleset
+++ b/Analyzers.Test/test.ruleset
@@ -4,6 +4,15 @@
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
     <Rule Id="IDE0073" Action="None"/> <!-- Disable Require file header -->
     <Rule Id="CS1591" Action="None"/> <!-- Disable Require Class documentaion -->
+
+    <!-- Disable C# 12 collection expression suggestions -->
+    <Rule Id="IDE0028" Action="None"/>
+    <Rule Id="IDE0290" Action="None"/>
+    <Rule Id="IDE0300" Action="None"/>
+    <Rule Id="IDE0301" Action="None"/>
+    <Rule Id="IDE0303" Action="None"/>
+    <Rule Id="IDE0305" Action="None"/>
+    <Rule Id="IDE0306" Action="None"/>
   </Rules>
 
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">

--- a/Analyzers/src/DataPointAttributeAnalyzer.cs
+++ b/Analyzers/src/DataPointAttributeAnalyzer.cs
@@ -3,8 +3,8 @@
 
 namespace GdUnit4.Analyzers;
 
+using System;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
@@ -30,7 +30,8 @@ public class DataPointAttributeAnalyzer : DiagnosticAnalyzer
     /// <param name="context">The analysis context to initialize.</param>
     public override void Initialize(AnalysisContext context)
     {
-        Debug.Assert(context != null, nameof(context) + " != null");
+        if (context is null)
+            throw new ArgumentNullException(nameof(context));
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
         context.RegisterSymbolAction(AnalyzeMethodSymbol, SymbolKind.Method);

--- a/Api/src/api/ITestEngineLogger.cs
+++ b/Api/src/api/ITestEngineLogger.cs
@@ -13,13 +13,6 @@ using System.Runtime.CompilerServices;
 public interface ITestEngineLogger
 {
     /// <summary>
-    ///     Sends a message to the enabled loggers.
-    /// </summary>
-    /// <param name="logLevel">Level of the message.</param>
-    /// <param name="message">The message to be sent.</param>
-    protected void SendMessage(LogLevel logLevel, string message);
-
-    /// <summary>
     ///     Logs an informational message.
     /// </summary>
     /// <param name="message">The informational message to log.</param>
@@ -39,4 +32,11 @@ public interface ITestEngineLogger
     /// <param name="message">The error message to log.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     void LogError(string message) => SendMessage(LogLevel.Error, message);
+
+    /// <summary>
+    ///     Sends a message to the enabled loggers.
+    /// </summary>
+    /// <param name="logLevel">Level of the message.</param>
+    /// <param name="message">The message to be sent.</param>
+    protected void SendMessage(LogLevel logLevel, string message);
 }

--- a/Api/src/core/data/DataPointValueProvider.cs
+++ b/Api/src/core/data/DataPointValueProvider.cs
@@ -103,7 +103,7 @@ internal static class DataPointValueProvider
         if (!IsAsyncEnumerableType(returnType!))
             throw new ArgumentException($"Data source '{dataPoint.DataPointSource}' in {declaringType.FullName} must return IAsyncEnumerable<T>");
 
-        await foreach (var item in StreamAsyncData(dataSource, returnType!, timeout))
+        await foreach (var item in StreamAsyncData(dataSource, returnType!, timeout).ConfigureAwait(false))
             yield return item;
     }
 

--- a/Api/src/core/execution/ExecutionContext.cs
+++ b/Api/src/core/execution/ExecutionContext.cs
@@ -218,7 +218,7 @@ internal sealed class ExecutionContext : IDisposable
     {
         var orphanCount = MemoryPool.OrphanCount;
         if (recursive)
-            orphanCount += SubExecutionContexts.Select(context => context.MemoryPool.OrphanCount).Sum();
+            orphanCount += SubExecutionContexts.Sum(context => context.MemoryPool.OrphanCount);
         return orphanCount;
     }
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,16 +5,10 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-
-    <!-- Note: Keep GodotVersion in sync with global.json msbuild-sdks.Godot.NET.Sdk -->
-    <GodotVersion>4.3</GodotVersion>
-    <GodotNetSdkVersion>$(GodotVersion)</GodotNetSdkVersion>
-    <CommonTargetFrameworks Condition="'$(CommonTargetFrameworks)' == ''">net7.0;net8.0</CommonTargetFrameworks>
-    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
 
-  <!-- Default .NET 8 compatible versions -->
-  <ItemGroup>
+  <!-- Analyzer packages for netstandard2.0 -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.9.2"/>
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0"/>
@@ -30,8 +24,49 @@
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507"/>
     <PackageVersion Include="Gu.Roslyn.Asserts" Version="4.3.0"/>
     <PackageVersion Include="Gu.Roslyn.Asserts.Analyzers" Version="4.0.0"/>
+  </ItemGroup>
 
 
+  <!-- .NET 8 compatible versions when targeting net8.0 -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.9.2"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2"/>
+    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.9.0"/>
+    <PackageVersion Include="Microsoft.TestPlatform.AdapterUtilities" Version="17.9.0"/>
+
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.2.0"/>
+    <PackageVersion Include="MSTest.TestFramework" Version="3.2.0"/>
+
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507"/>
+    <PackageVersion Include="Gu.Roslyn.Asserts" Version="4.3.0"/>
+    <PackageVersion Include="Gu.Roslyn.Asserts.Analyzers" Version="4.0.0"/>
+  </ItemGroup>
+
+  <!-- .NET 9 compatible versions when targeting net9.0 -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.11.0"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0"/>
+    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.12.0"/>
+    <PackageVersion Include="Microsoft.TestPlatform.AdapterUtilities" Version="17.12.0"/>
+
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.9.2"/>
+    <PackageVersion Include="MSTest.TestFramework" Version="3.9.2"/>
+
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556"/>
+    <PackageVersion Include="Gu.Roslyn.Asserts" Version="4.3.0"/>
+    <PackageVersion Include="Gu.Roslyn.Asserts.Analyzers" Version="4.0.0"/>
+  </ItemGroup>
+
+
+  <ItemGroup>
     <PackageVersion Include="Godot.NET.Sdk" Version="$(GodotNetSdkVersion)"/>
     <PackageVersion Include="GodotSharp" Version="$(GodotNetSdkVersion)"/>
     <PackageVersion Include="Godot.SourceGenerators" Version="$(GodotNetSdkVersion)"/>

--- a/ProjectVersions.props
+++ b/ProjectVersions.props
@@ -4,4 +4,16 @@
     <GdUnitAPIVersion>5.0.0-rc3</GdUnitAPIVersion>
     <GdUnitTestAdapterVersion>3.0.0-rc1</GdUnitTestAdapterVersion>
   </PropertyGroup>
+
+
+  <PropertyGroup>
+    <!-- Note: Keep GodotVersion in sync with global.json msbuild-sdks.Godot.NET.Sdk -->
+    <GodotVersion>4.4</GodotVersion>
+    <GodotNetSdkVersion>$(GodotVersion)</GodotNetSdkVersion>
+
+    <!-- Common build properties -->
+    <CommonTargetFrameworks Condition="'$(CommonTargetFrameworks)' == ''">net8.0;net9.0</CommonTargetFrameworks>
+    <LangVersion>12.0</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
 </Project>

--- a/TestAdapter.Test/test.ruleset
+++ b/TestAdapter.Test/test.ruleset
@@ -4,6 +4,15 @@
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
     <Rule Id="IDE0073" Action="None"/> <!-- Disable Require file header -->
     <Rule Id="CS1591" Action="None"/> <!-- Disable Require Class documentaion -->
+
+    <!-- Disable C# 12 collection expression suggestions -->
+    <Rule Id="IDE0028" Action="None"/>
+    <Rule Id="IDE0290" Action="None"/>
+    <Rule Id="IDE0300" Action="None"/>
+    <Rule Id="IDE0301" Action="None"/>
+    <Rule Id="IDE0303" Action="None"/>
+    <Rule Id="IDE0305" Action="None"/>
+    <Rule Id="IDE0306" Action="None"/>
   </Rules>
 
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">

--- a/TestAdapter.Test/test/execution/TestCaseFilterTest.cs
+++ b/TestAdapter.Test/test/execution/TestCaseFilterTest.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
 namespace GdUnit4.TestAdapter.Test.Execution;
 
 using System;

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "8.0.411",
+    "version": "9.0.301",
     "rollForward": "latestPatch"
   },
   "msbuild-sdks": {
-    "Godot.NET.Sdk": "4.3"
+    "Godot.NET.Sdk": "4.4"
   }
 }

--- a/stylecop.ruleset
+++ b/stylecop.ruleset
@@ -14,5 +14,13 @@
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
     <Rule Id="IDE0011" Action="None"/> <!-- Disable Add braces to 'if' statement -->
+    <!-- Disable C# 12 collection expression suggestions -->
+    <Rule Id="IDE0028" Action="None"/>
+    <Rule Id="IDE0290" Action="None"/>
+    <Rule Id="IDE0300" Action="None"/>
+    <Rule Id="IDE0301" Action="None"/>
+    <Rule Id="IDE0303" Action="None"/>
+    <Rule Id="IDE0305" Action="None"/>
+    <Rule Id="IDE0306" Action="None"/>
   </Rules>
 </RuleSet>


### PR DESCRIPTION
# What:
- Remove .NET 7 support
- Add .NET 9 support
- Set LangVersion to 12.0
- Temporarily disable C# 12 style warnings (IDE0028, IDE0290, IDE0300-IDE0306. ..)

Why:
- .NET 7 is going out of support
- .NET 8 is the current LTS version
- C# 12 is required for .NET 9 source generator compatibility
- Style warnings suppressed to maintain existing code patterns during transition