### PR TITLE
Consolidate and modernize C# code style configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -381,6 +381,9 @@ dotnet_diagnostic.SA1637.severity = none # File header must contain file name
 dotnet_diagnostic.SA1638.severity = none # File header file name documentation must match file name
 dotnet_diagnostic.SA1634.severity = none # File header must show copyright
 
+# IDE rules overrides
+dotnet_diagnostic.IDE0130.severity = none # Namespace does not match folder structure
+
 # Allow underscore in constant names (for SCREAMING_SNAKE_CASE)
 dotnet_diagnostic.SA1310.severity = none
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,14 +1,32 @@
-# Version: 4.1.1 (Using https://semver.org/)
-# Updated: 2022-05-23
-# See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
-# See https://github.com/RehanSaeed/EditorConfig for updates to this file.
+##########################################
+# Copyright & License Information
+##########################################
+#
+# Copyright (c) 2025 Mike Schulze
+# MIT License - See LICENSE file in the repository root for full license text
+#
+# This .editorconfig file is part of the GdUnit4Net project and is licensed
+# under the MIT License. You may obtain a copy of the License at:
+# https://github.com/MikeSchulze/gdUnit4Net/blob/master/LICENSE
+#
+# This configuration provides consistent code formatting and style rules
+# for the GdUnit4Net C# test framework across different editors and IDEs.
+#
+# For more information about EditorConfig, visit: https://editorconfig.org
+# For GdUnit4Net documentation, visit: https://github.com/MikeSchulze/gdUnit4Net
+#
+##########################################
+
+
+# Version: 5.0.0 (GdUnit4 Consolidated - C# 12)
+# Updated: 2025-06-15
+# Consolidated configuration with C# 12 features enabled
 # See http://EditorConfig.org for more information about .editorconfig files.
 
 ##########################################
 # Common Settings
 ##########################################
 
-# This file is the top-most EditorConfig file
 root = true
 
 # All Files
@@ -19,11 +37,6 @@ indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 max_line_length = 180
-# Roslynator settings for line length
-roslynator_max_line_length = max_line_length
-resharper_wrap_lines = true
-resharper_hard_wrap_line_length = max_line_length
-csharp_max_line_length = max_line_length
 
 ##########################################
 # File Extension Settings
@@ -70,67 +83,41 @@ end_of_line = lf
 indent_style = tab
 
 ##########################################
-# Default .NET Code Style Severities
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/configuration-options#scope
+# .NET Code Style and Analysis
 ##########################################
 
 [*.{cs,csx,cake,vb,vbx}]
-# Default Severity for all .NET Code Style rules below
+# Default severity for all .NET Code Style rules
 dotnet_analyzer_diagnostic.severity = warning
 
+# GdUnit4 File header configuration
+file_header_template = Copyright (c) 2025 Mike Schulze\nMIT License - See LICENSE file in the repository root for full license text
+
 ##########################################
-# Language Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules
+# Language Rules - .NET Style Rules
 ##########################################
 
-# .NET Style Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#net-style-rules
-[*.{cs,csx,cake,vb,vbx}]
-# "this." and "Me." qualifiers
-dotnet_style_qualification_for_field = true : warning
-dotnet_style_qualification_for_property = true : warning
-dotnet_style_qualification_for_method = true : warning
-dotnet_style_qualification_for_event = true : warning
+# "this." and "Me." qualifiers (GdUnit4 preference: disabled)
+dotnet_style_qualification_for_field = false : warning
+dotnet_style_qualification_for_property = false : warning
+dotnet_style_qualification_for_method = false : warning
+dotnet_style_qualification_for_event = false : warning
 
-# Format document on save - for JetBrains Rider
-resharper_apply_on_save = true
-
-
-# Member ordering
-resharper_member_order = accessibility, kind
-resharper_member_modifier_order = internal static, protected static, private static, static, internal, protected, private
-resharper_kind_order = constant, field, constructor, destructor, delegate, event, enum, interface, property, indexer, operator, method, struct, class
-resharper_accessibility_order = public, internal, protected, private
-
-resharper_arrange_member_access_first = true
-resharper_arrange_static_member_qualifier = true
-resharper_arrange_type_member_modifiers = true
-resharper_arrange_type_modifiers = true
-
-# Force member reordering to be active
-resharper_member_reordering_patterns = true
-
-# Make sure ReSharper member ordering is enabled
-resharper_apply_member_ordering_pattern = true
-
-# Sort using directives
-dotnet_sort_system_directives_first = true
-dotnet_separate_import_directive_groups = true
-
-
-# Language keywords instead of framework type names for type references
+# Language keywords vs framework types
 dotnet_style_predefined_type_for_locals_parameters_members = true : warning
 dotnet_style_predefined_type_for_member_access = true : warning
+
 # Modifier preferences
 dotnet_style_require_accessibility_modifiers = for_non_interface_members : warning
 csharp_preferred_modifier_order = public, private, protected, internal, required, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async : warning
-visual_basic_preferred_modifier_order = Partial, Default, Private, Protected, Public, Friend, NotOverridable, Overridable, MustOverride, Overloads, Overrides, MustInherit, NotInheritable, Static, Shared, Shadows, ReadOnly, WriteOnly, Dim, Const, WithEvents, Widening, Narrowing, Custom, Async : warning
 dotnet_style_readonly_field = true : warning
+
 # Parentheses preferences
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity : warning
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity : warning
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity : warning
 dotnet_style_parentheses_in_other_operators = never_if_unnecessary : warning
+
 # Expression-level preferences
 dotnet_style_object_initializer = true : warning
 dotnet_style_collection_initializer = true : warning
@@ -139,34 +126,45 @@ dotnet_style_prefer_inferred_tuple_names = true : warning
 dotnet_style_prefer_inferred_anonymous_type_member_names = true : warning
 dotnet_style_prefer_auto_properties = true : warning
 dotnet_style_prefer_conditional_expression_over_assignment = false : suggestion
-dotnet_diagnostic.IDE0045.severity = suggestion
 dotnet_style_prefer_conditional_expression_over_return = false : suggestion
-dotnet_diagnostic.IDE0046.severity = suggestion
 dotnet_style_prefer_compound_assignment = true : warning
 dotnet_style_prefer_simplified_interpolation = true : warning
 dotnet_style_prefer_simplified_boolean_expressions = true : warning
+
 # Null-checking preferences
 dotnet_style_coalesce_expression = true : warning
 dotnet_style_null_propagation = true : warning
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true : warning
-# File header preferences
-# file_header_template = <copyright file="{fileName}" company="PROJECT-AUTHOR">\n© PROJECT-AUTHOR\n</copyright>
-# If you use StyleCop, you'll need to disable SA1636: File header copyright text should match.
-dotnet_diagnostic.SA1633.severity = none
 
-# Set C# new line preferences
-# Controls placement of binary operators when wrapping expressions
-# Place operators at the beginning of the line (Rider/ReSharper specific setting)
+# Organize using directives
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = true
+
+# Namespace options
+dotnet_style_namespace_match_folder = true : suggestion
+
+# Operator placement
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
-csharp_new_line_before_binary_operators = false
 
-# C# Style Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#c-style-rules
+##########################################
+# C# 12 Specific Language Rules
+##########################################
+
 [*.{cs,csx,cake}]
+# C# 12 Primary constructors
+csharp_style_prefer_primary_constructors = true : suggestion
+
+# C# 12 Collection expressions
+csharp_style_prefer_collection_expression = when_types_exactly_match : suggestion
+
+# C# 12 Default lambda parameters
+csharp_style_prefer_default_literal = true : warning
+
 # 'var' preferences
 csharp_style_var_for_built_in_types = true : warning
 csharp_style_var_when_type_is_apparent = true : warning
 csharp_style_var_elsewhere = true : warning
+
 # Expression-bodied members
 csharp_style_expression_bodied_methods = true : warning
 csharp_style_expression_bodied_constructors = true : warning
@@ -176,12 +174,15 @@ csharp_style_expression_bodied_indexers = true : warning
 csharp_style_expression_bodied_accessors = true : warning
 csharp_style_expression_bodied_lambdas = true : warning
 csharp_style_expression_bodied_local_functions = true : warning
-# Pattern matching preferences
+
+# Pattern matching preferences (enhanced in C# 12)
 csharp_style_pattern_matching_over_is_with_cast_check = true : warning
 csharp_style_pattern_matching_over_as_with_null_check = true : warning
 csharp_style_prefer_switch_expression = true : warning
 csharp_style_prefer_pattern_matching = true : warning
 csharp_style_prefer_not_pattern = true : warning
+csharp_style_prefer_extended_property_pattern = true : suggestion
+
 # Expression-level preferences
 csharp_style_inlined_variable_declaration = true : warning
 csharp_prefer_simple_default_expression = true : warning
@@ -190,85 +191,27 @@ csharp_style_deconstructed_variable_declaration = true : warning
 csharp_style_prefer_index_operator = true : warning
 csharp_style_prefer_range_operator = true : warning
 csharp_style_implicit_object_creation_when_type_is_apparent = true : warning
+csharp_style_prefer_utf8_string_literals = true : suggestion
+csharp_style_prefer_method_group_conversion = true : suggestion
+csharp_style_prefer_tuple_swap = true : suggestion
+csharp_style_prefer_readonly_struct = true : suggestion
+csharp_style_prefer_readonly_struct_member = true : suggestion
+
 # "Null" checking preferences
 csharp_style_throw_expression = true : warning
 csharp_style_conditional_delegate_call = true : warning
-# Enforce attributes on separate lines
-dotnet_diagnostic.SA1134.severity = warning
-# Alternative: Use IDE rules for attribute placement
-csharp_style_prefer_attributes_on_same_line = false
-dotnet_diagnostic.IDE0055.severity = warning
-
-# ReSharper/Rider specific settings for attribute placement
-resharper_place_attribute_on_same_line = false
-resharper_place_simple_attribute_on_same_line = false
-resharper_place_type_attribute_on_same_line = false
-resharper_place_method_attribute_on_same_line = false
-resharper_place_accessor_attribute_on_same_line = false
-resharper_place_field_attribute_on_same_line = false
-# Don't require localization for string literals
-dotnet_diagnostic.CA1303.severity = none
 
 # Code block preferences
 csharp_prefer_braces = when_multiline : warning
 csharp_prefer_simple_using_statement = true : suggestion
-dotnet_diagnostic.IDE0063.severity = suggestion
+
 # 'using' directive preferences
 csharp_using_directive_placement = inside_namespace : warning
+
 # Modifier preferences
 csharp_prefer_static_local_function = true : warning
-# Disable StyleCop rule for requiring braces for single-line statements
-dotnet_diagnostic.SA1503.severity = none
-resharper_redundant_block_braces_highlighting = do_not_show
-resharper_redundant_empty_declaration_highlighting = do_not_show
-resharper_remove_redundant_braces_highlighting = do_not_show
 
-##########################################
-# Unnecessary Code Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/unnecessary-code-rules
-##########################################
-
-# .NET Unnecessary code rules
-[*.{cs,csx,cake,vb,vbx}]
-dotnet_code_quality_unused_parameters = all : warning
-dotnet_remove_unnecessary_suppression_exclusions = none : warning
-
-# C# Unnecessary code rules
-[*.{cs,csx,cake}]
-csharp_style_unused_value_expression_statement_preference = discard_variable : suggestion
-dotnet_diagnostic.IDE0058.severity = suggestion
-csharp_style_unused_value_assignment_preference = discard_variable : suggestion
-dotnet_diagnostic.IDE0059.severity = suggestion
-
-
-##########################################
-# Test suite rules
-##########################################
-# Exclude test files from certain rules
-[**/*Test.cs]
-dotnet_diagnostic.CA1515.severity = none
-
-##########################################
-# Formatting Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules
-##########################################
-
-# .NET formatting rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#net-formatting-rules
-[*.{cs,csx,cake,vb,vbx}]
-# Organize using directives
-dotnet_sort_system_directives_first = true
-# Dotnet namespace options
-dotnet_style_namespace_match_folder = true : suggestion
-dotnet_diagnostic.IDE0130.severity = suggestion
-# Disable requirement for qualified using directives
-dotnet_diagnostic.SA1135.severity = none
-
-# C# formatting rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#c-formatting-rules
-[*.{cs,csx,cake}]
-# Newline options
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#new-line-options
+# New line preferences
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
@@ -276,16 +219,17 @@ csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
-# Indentation options
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#indentation-options
+csharp_new_line_before_binary_operators = false
+
+# Indentation preferences
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 csharp_indent_labels = no_change
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents_when_block = false
-# Spacing options
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#spacing-options
+
+# Spacing preferences
 csharp_space_after_cast = false
 csharp_space_after_keywords_in_control_flow_statements = true
 csharp_space_between_parentheses = false
@@ -309,311 +253,178 @@ csharp_space_before_open_square_brackets = false
 csharp_space_between_empty_square_brackets = false
 csharp_space_between_square_brackets = false
 
-# Specifically for new keyword space
+# Wrap preferences
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
+
+# Namespace preferences (C# 10+)
+csharp_style_namespace_declarations = file_scoped : warning
+
+##########################################
+# Dead Code Analysis
+##########################################
+
+# .NET dead code analysis
+dotnet_code_quality_unused_parameters = all : warning
+dotnet_remove_unnecessary_suppression_exclusions = none : warning
+
+# C# dead code analysis
+csharp_style_unused_value_expression_statement_preference = discard_variable : suggestion
+csharp_style_unused_value_assignment_preference = discard_variable : suggestion
+
+
+##########################################
+# Naming Rules
+##########################################
+
+# Styles
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+dotnet_naming_style.all_caps_style.capitalization = all_upper
+dotnet_naming_style.prefix_interface_with_i_style.capitalization = pascal_case
+dotnet_naming_style.prefix_interface_with_i_style.required_prefix = I
+dotnet_naming_style.prefix_type_parameters_with_t_style.capitalization = pascal_case
+dotnet_naming_style.prefix_type_parameters_with_t_style.required_prefix = T
+
+# Constants - SCREAMING_SNAKE_CASE or PascalCase
+dotnet_naming_symbols.constant_fields.applicable_kinds = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = *
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_rule.constant_fields_should_be_all_caps.symbols = constant_fields
+dotnet_naming_rule.constant_fields_should_be_all_caps.style = all_caps_style
+dotnet_naming_rule.constant_fields_should_be_all_caps.severity = suggestion
+
+# Static readonly fields - PascalCase
+dotnet_naming_symbols.static_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities = *
+dotnet_naming_symbols.static_readonly_fields.required_modifiers = static, readonly
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.symbols = static_readonly_fields
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.severity = warning
+
+# Private fields - camelCase
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+dotnet_naming_rule.private_fields_should_be_camel_case.symbols = private_fields
+dotnet_naming_rule.private_fields_should_be_camel_case.style = camel_case_style
+dotnet_naming_rule.private_fields_should_be_camel_case.severity = warning
+
+# Interfaces - PascalCase with I prefix
+dotnet_naming_symbols.interfaces.applicable_kinds = interface
+dotnet_naming_rule.interfaces_should_be_prefixed_with_i.symbols = interfaces
+dotnet_naming_rule.interfaces_should_be_prefixed_with_i.style = prefix_interface_with_i_style
+dotnet_naming_rule.interfaces_should_be_prefixed_with_i.severity = warning
+
+# Type parameters - PascalCase with T prefix
+dotnet_naming_symbols.type_parameters.applicable_kinds = type_parameter
+dotnet_naming_rule.type_parameters_should_be_prefixed_with_t.symbols = type_parameters
+dotnet_naming_rule.type_parameters_should_be_prefixed_with_t.style = prefix_type_parameters_with_t_style
+dotnet_naming_rule.type_parameters_should_be_prefixed_with_t.severity = warning
+
+# Methods, properties, events, classes, etc. - PascalCase
+dotnet_naming_symbols.pascal_case_symbols.applicable_kinds = namespace, class, struct, enum, delegate, event, method, property
+dotnet_naming_rule.pascal_case_symbols_should_be_pascal_case.symbols = pascal_case_symbols
+dotnet_naming_rule.pascal_case_symbols_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_rule.pascal_case_symbols_should_be_pascal_case.severity = warning
+
+# Parameters and locals - camelCase
+dotnet_naming_symbols.parameters_and_locals.applicable_kinds = parameter, local
+dotnet_naming_rule.parameters_and_locals_should_be_camel_case.symbols = parameters_and_locals
+dotnet_naming_rule.parameters_and_locals_should_be_camel_case.style = camel_case_style
+dotnet_naming_rule.parameters_and_locals_should_be_camel_case.severity = warning
+
+##########################################
+# ReSharper/Rider Specific Settings
+##########################################
+
+# Member ordering
+resharper_member_order = accessibility, kind
+resharper_arrange_member_access_first = true
+resharper_arrange_static_member_qualifier = true
+resharper_arrange_type_member_modifiers = true
+resharper_arrange_type_modifiers = true
+resharper_apply_member_ordering_pattern = true
+
+# Blank lines
+resharper_blank_lines_after_block_statements = 1
+resharper_blank_lines_around_single_line_type = 1
+resharper_blank_lines_around_field = 1
+resharper_blank_lines_around_property = 1
+resharper_blank_lines_around_method = 1
+resharper_blank_lines_after_using_list = 1
+resharper_keep_blank_lines_in_code = 1
+resharper_keep_blank_lines_in_declarations = 1
+resharper_remove_blank_lines_near_braces = true
+resharper_blank_lines_between_using_groups = 1
+
+# Spacing
 resharper_space_within_single_line_array_initializer_braces = true
 resharper_space_in_singleline_method = true
 resharper_space_after_new_expression = true
-resharper_space_after_type_parameter_constraint_colon = true
-dotnet_diagnostic.SA1000.severity = none
 
+# Attributes
+resharper_place_attribute_on_same_line = false
+resharper_place_simple_attribute_on_same_line = false
 
-# Wrap options
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#wrap-options
-csharp_preserve_single_line_statements = false
-csharp_preserve_single_line_blocks = true
-# Namespace options
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#namespace-options
-csharp_style_namespace_declarations = file_scoped : warning
-# Disable StyleCop SA1118 (Parameter should not span multiple lines)
-dotnet_diagnostic.SA1118.severity = none
-
+# Format on save
+resharper_apply_on_save = true
 
 ##########################################
-# .NET Naming Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/naming-rules
+# StyleCop and Code Quality Overrides
 ##########################################
 
-[*.{cs,csx,cake,vb,vbx}]
-
-##########################################
-# Styles
-##########################################
-
-# camel_case_style - Define the camelCase style
-dotnet_naming_style.camel_case_style.capitalization = camel_case
-# pascal_case_style - Define the PascalCase style
-dotnet_naming_style.pascal_case_style.capitalization = pascal_case
-# first_upper_style - The first character must start with an upper-case character
-dotnet_naming_style.first_upper_style.capitalization = first_word_upper
-# prefix_interface_with_i_style - Interfaces must be PascalCase and the first character of an interface must be an 'I'
-dotnet_naming_style.prefix_interface_with_i_style.capitalization = pascal_case
-dotnet_naming_style.prefix_interface_with_i_style.required_prefix = I
-# prefix_type_parameters_with_t_style - Generic Type Parameters must be PascalCase and the first character must be a 'T'
-dotnet_naming_style.prefix_type_parameters_with_t_style.capitalization = pascal_case
-dotnet_naming_style.prefix_type_parameters_with_t_style.required_prefix = T
-# disallowed_style - Anything that has this style applied is marked as disallowed
-dotnet_naming_style.disallowed_style.capitalization = pascal_case
-dotnet_naming_style.disallowed_style.required_prefix = ____RULE_VIOLATION____
-dotnet_naming_style.disallowed_style.required_suffix = ____RULE_VIOLATION____
-# internal_error_style - This style should never occur... if it does, it indicates a bug in file or in the parser using the file
-dotnet_naming_style.internal_error_style.capitalization = pascal_case
-dotnet_naming_style.internal_error_style.required_prefix = ____INTERNAL_ERROR____
-dotnet_naming_style.internal_error_style.required_suffix = ____INTERNAL_ERROR____
-
-##########################################
-# .NET Design Guideline Field Naming Rules
-# Naming rules for fields follow the .NET Framework design guidelines
-# https://docs.microsoft.com/dotnet/standard/design-guidelines/index
-##########################################
-
-# All public/protected/protected_internal constant fields must be PascalCase
-# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
-dotnet_naming_symbols.public_protected_constant_fields_group.applicable_accessibilities = public, protected, protected_internal
-dotnet_naming_symbols.public_protected_constant_fields_group.required_modifiers = const
-dotnet_naming_symbols.public_protected_constant_fields_group.applicable_kinds = field
-dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.symbols = public_protected_constant_fields_group
-dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.style = pascal_case_style
-dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.severity = warning
-
-# All public/protected/protected_internal static readonly fields must be PascalCase
-# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
-dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_accessibilities = public, protected, protected_internal
-dotnet_naming_symbols.public_protected_static_readonly_fields_group.required_modifiers = static, readonly
-dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_kinds = field
-dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.symbols = public_protected_static_readonly_fields_group
-dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.style = pascal_case_style
-dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.severity = warning
-
-# No other public/protected/protected_internal fields are allowed
-# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
-dotnet_naming_symbols.other_public_protected_fields_group.applicable_accessibilities = public, protected, protected_internal
-dotnet_naming_symbols.other_public_protected_fields_group.applicable_kinds = field
-dotnet_naming_rule.other_public_protected_fields_disallowed_rule.symbols = other_public_protected_fields_group
-dotnet_naming_rule.other_public_protected_fields_disallowed_rule.style = disallowed_style
-dotnet_naming_rule.other_public_protected_fields_disallowed_rule.severity = error
-
-##########################################
-# StyleCop Field Naming Rules
-# Naming rules for fields follow the StyleCop analyzers
-# This does not override any rules using disallowed_style above
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers
-##########################################
-
-# All constant fields must be PascalCase
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
-dotnet_naming_style.all_caps_style.capitalization = all_upper
-dotnet_naming_symbols.stylecop_constant_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
-dotnet_naming_symbols.stylecop_constant_fields_group.required_modifiers = const
-dotnet_naming_symbols.stylecop_constant_fields_group.applicable_kinds = field
-dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.symbols = stylecop_constant_fields_group
-dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.style = all_caps_style
-dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.severity = warning
-
-# All static readonly fields must be PascalCase
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
-dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
-dotnet_naming_symbols.stylecop_static_readonly_fields_group.required_modifiers = static, readonly
-dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_kinds = field
-dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.symbols = stylecop_static_readonly_fields_group
-dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.style = pascal_case_style
-dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.severity = warning
-
-# No non-private instance fields are allowed
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
-dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected
-dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_kinds = field
-dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.symbols = stylecop_fields_must_be_private_group
-dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.style = disallowed_style
-dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.severity = error
-
-# Private fields must be camelCase
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
-dotnet_naming_symbols.stylecop_private_fields_group.applicable_accessibilities = private
-dotnet_naming_symbols.stylecop_private_fields_group.applicable_kinds = field
-dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.symbols = stylecop_private_fields_group
-dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.style = camel_case_style
-dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.severity = warning
-
-# Local variables must be camelCase
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
-dotnet_naming_symbols.stylecop_local_fields_group.applicable_accessibilities = local
-dotnet_naming_symbols.stylecop_local_fields_group.applicable_kinds = local
-dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.symbols = stylecop_local_fields_group
-dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.style = camel_case_style
-dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.severity = silent
-
-# This rule should never fire.  However, it's included for at least two purposes:
-# First, it helps to understand, reason about, and root-case certain types of issues, such as bugs in .editorconfig parsers.
-# Second, it helps to raise immediate awareness if a new field type is added (as occurred recently in C#).
-dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_accessibilities = *
-dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_kinds = field
-dotnet_naming_rule.sanity_check_uncovered_field_case_rule.symbols = sanity_check_uncovered_field_case_group
-dotnet_naming_rule.sanity_check_uncovered_field_case_rule.style = internal_error_style
-dotnet_naming_rule.sanity_check_uncovered_field_case_rule.severity = error
-
-
-##########################################
-# Other Naming Rules
-##########################################
-
-# All of the following must be PascalCase:
-# - Namespaces
-#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-namespaces
-#   https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
-# - Classes and Enumerations
-#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
-#   https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
-# - Delegates
-#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces#names-of-common-types
-# - Constructors, Properties, Events, Methods
-#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-type-members
-dotnet_naming_symbols.element_group.applicable_kinds = namespace, class, enum, struct, delegate, event, method, property
-dotnet_naming_rule.element_rule.symbols = element_group
-dotnet_naming_rule.element_rule.style = pascal_case_style
-dotnet_naming_rule.element_rule.severity = warning
-
-# Interfaces use PascalCase and are prefixed with uppercase 'I'
-# https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
-dotnet_naming_symbols.interface_group.applicable_kinds = interface
-dotnet_naming_rule.interface_rule.symbols = interface_group
-dotnet_naming_rule.interface_rule.style = prefix_interface_with_i_style
-dotnet_naming_rule.interface_rule.severity = warning
-
-# Generics Type Parameters use PascalCase and are prefixed with uppercase 'T'
-# https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
-dotnet_naming_symbols.type_parameter_group.applicable_kinds = type_parameter
-dotnet_naming_rule.type_parameter_rule.symbols = type_parameter_group
-dotnet_naming_rule.type_parameter_rule.style = prefix_type_parameters_with_t_style
-dotnet_naming_rule.type_parameter_rule.severity = warning
-
-# Function parameters use camelCase
-# https://docs.microsoft.com/dotnet/standard/design-guidelines/naming-parameters
-dotnet_naming_symbols.parameters_group.applicable_kinds = parameter
-dotnet_naming_rule.parameters_rule.symbols = parameters_group
-dotnet_naming_rule.parameters_rule.style = camel_case_style
-dotnet_naming_rule.parameters_rule.severity = warning
-
-##########################################
-# License
-##########################################
-# The following applies as to the .editorconfig file ONLY, and is
-# included below for reference, per the requirements of the license
-# corresponding to this .editorconfig file.
-# See: https://github.com/RehanSaeed/EditorConfig
-#
-# MIT License
-#
-# Copyright (c) 2017-2019 Muhammad Rehan Saeed
-# Copyright (c) 2019 Henry Gabryjelski
-#
-# Permission is hereby granted, free of charge, to any
-# person obtaining a copy of this software and associated
-# documentation files (the "Software"), to deal in the
-# Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute,
-# sublicense, and/or sell copies of the Software, and to permit
-# persons to whom the Software is furnished to do so, subject
-# to the following conditions:
-#
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-# OTHER DEALINGS IN THE SOFTWARE.
-##########################################
-
-
-#########################################################################################################
 # GdUnit4 specific overrides
-#########################################################################################################
-
-# Configure file header template
-file_header_template = Copyright (c) 2025 Mike Schulze\nMIT License - See LICENSE file in the repository root for full license text
-# Enable file header rules
+dotnet_diagnostic.SA1101.severity = none # Don't require 'this.' prefix
 dotnet_diagnostic.SA1633.severity = error # File must have header
 dotnet_diagnostic.SA1635.severity = error # File header must have copyright text
 dotnet_diagnostic.SA1637.severity = none # File header must contain file name
 dotnet_diagnostic.SA1638.severity = none # File header file name documentation must match file name
 dotnet_diagnostic.SA1634.severity = none # File header must show copyright
 
-# .NET formatting rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#net-formatting-rules
-[*.{cs,csx,cake,vb,vbx}]
-# Organize using directives
-dotnet_separate_import_directive_groups = true
-
-dotnet_style_qualification_for_field = false : warning
-dotnet_style_qualification_for_property = false : warning
-dotnet_style_qualification_for_method = false : warning
-dotnet_style_qualification_for_event = false : warning
-dotnet_diagnostic.SA1101.severity = none
-
-dotnet_diagnostic.CA1822.severity = none
-
-# Don't require culture info for ToString()
-dotnet_diagnostic.CA1304.severity = none
-# Don't require a string format specifier.
-dotnet_diagnostic.CA1305.severity = none
-# Don't require culture info for Specify StringComparison for correctness
-dotnet_diagnostic.CA1310.severity = none
-# Don't require culture info for String.ToUpper() or String.ToLower() without specifying a culture.
-dotnet_diagnostic.CA1311.severity = none
-
-# Default severity for analyzer diagnostics with category 'Usage'
-dotnet_analyzer_diagnostic.category-Usage.severity = warning
-
-# allow constant arrays as arguments
-dotnet_diagnostic.CA1861.severity = none
-
-#### Define naming rules for constants
-
-# Disable StyleCop's underscore rule that prevents SCREAMING_SNAKE_CASE
+# Allow underscore in constant names (for SCREAMING_SNAKE_CASE)
 dotnet_diagnostic.SA1310.severity = none
 
+# Disable braces requirements for single-line statements
+dotnet_diagnostic.SA1503.severity = none
 
-# This will make everything that isn't already covered use PascalCase
-dotnet_naming_symbols.remaining_symbols.applicable_kinds = *
-dotnet_naming_symbols.remaining_symbols.applicable_accessibilities = *
+# Disable parameter spanning multiple lines requirement
+dotnet_diagnostic.SA1118.severity = none
 
-# Make everything else use PascalCase
-dotnet_naming_rule.remaining_symbols_should_be_pascal_case.symbols = remaining_symbols
-dotnet_naming_rule.remaining_symbols_should_be_pascal_case.style = pascal_case_style
-dotnet_naming_rule.remaining_symbols_should_be_pascal_case.severity = warning
+# Disable requirements for qualified using directives
+dotnet_diagnostic.SA1135.severity = none
 
-
-# ReSharper/Rider specific settings for blank lines
-resharper_blank_lines_after_block_statements = 1
-resharper_blank_lines_around_single_line_type = 1
-resharper_blank_lines_around_field = 1
-resharper_blank_lines_around_property = 1
-resharper_blank_lines_around_method = 1
-resharper_csharp_blank_lines_around_method = 1
-resharper_blank_lines_after_start_comment = 0
-resharper_blank_lines_after_block_comment = 0
-resharper_blank_lines_before_single_line_comment = 1
-resharper_blank_lines_after_using_list = 1
-resharper_keep_blank_lines_in_code = 1
-resharper_csharp_keep_blank_lines_in_code = 1
-resharper_remove_blank_lines_near_braces = true
-resharper_blank_lines_between_using_groups = 1
-
-# Ensure Rider keeps 1 blank line max in declarations
-resharper_keep_blank_lines_in_declarations = 1
-resharper_csharp_keep_blank_lines_in_declarations = 1
-dotnet_diagnostic.SA1507.severity = warning
-
-# ignore trailing commas
+# Allow trailing commas
 dotnet_diagnostic.SA1413.severity = none
 
+# Blank line rules
+dotnet_diagnostic.SA1507.severity = warning
 
-# Rider/ReSharper specific settings
-resharper_csharp_default_case_must_be_last = true
-resharper_empty_case_block_style = allowed
-resharper_default_case_seen_as_redundant = true
-resharper_redundant_empty_switch_section_highlighting = do_not_show
+# Don't require localization
+dotnet_diagnostic.CA1303.severity = none
+dotnet_diagnostic.CA1304.severity = none
+dotnet_diagnostic.CA1305.severity = none
+dotnet_diagnostic.CA1310.severity = none
+dotnet_diagnostic.CA1311.severity = none
+dotnet_diagnostic.CA1822.severity = none
+dotnet_diagnostic.CA1861.severity = none # Allow constant arrays as arguments
+
+# Usage category warnings
+dotnet_analyzer_diagnostic.category-Usage.severity = warning
+
+# C# 12 collection expression rules (enable selectively)
+dotnet_diagnostic.IDE0028.severity = suggestion # Use collection initializers
+dotnet_diagnostic.IDE0290.severity = suggestion # Use primary constructor
+dotnet_diagnostic.IDE0300.severity = suggestion # Use collection expression for array
+dotnet_diagnostic.IDE0301.severity = suggestion # Use collection expression for empty
+dotnet_diagnostic.IDE0303.severity = suggestion # Use collection expression for create
+dotnet_diagnostic.IDE0305.severity = suggestion # Use collection expression for fluent
+
+# Test-specific rules
+[**/*Test.cs]
+dotnet_diagnostic.CA1515.severity = none
+
+##########################################
+# License
+##########################################
+# Based on https://github.com/RehanSaeed/EditorConfig
+# MIT License - See original project for full license text

--- a/Analyzers.Test/src/DataPointAttributeAnalyzerTest.cs
+++ b/Analyzers.Test/src/DataPointAttributeAnalyzerTest.cs
@@ -66,7 +66,7 @@ public class DataPointAttributeAnalyzerTest
         var errorLine = new LinePosition(20, 1);
         var expected = ExpectedDiagnostic
             .Create(
-                DiagnosticRules.RuleIds.DataPointWithMultipleTestCase,
+                DiagnosticRules.RuleIds.DATA_POINT_WITH_MULTIPLE_TEST_CASE,
                 string.Format(
                     CultureInfo.InvariantCulture,
                     DiagnosticRules.DataPoint.MultipleTestCaseAttributes.MessageFormat.ToString(),

--- a/Analyzers.Test/src/GodotRuntimeRequireOnTestCaseAttributeTest.cs
+++ b/Analyzers.Test/src/GodotRuntimeRequireOnTestCaseAttributeTest.cs
@@ -31,7 +31,7 @@ public class GodotRuntimeRequireOnTestCaseAttributeTest
         var errorLine = new LinePosition(19, 12);
         var expected = ExpectedDiagnostic
             .Create(
-                DiagnosticRules.RuleIds.RequiresGodotRuntimeOnMethodId,
+                DiagnosticRules.RuleIds.REQUIRES_GODOT_RUNTIME_ON_METHOD_ID,
                 string.Format(
                     CultureInfo.InvariantCulture,
                     DiagnosticRules.GodotEngine.RequiresGodotRuntimeOnMethod.MessageFormat.ToString(),
@@ -54,7 +54,7 @@ public class GodotRuntimeRequireOnTestCaseAttributeTest
         var errorLine = new LinePosition(19, 12);
         var expected = ExpectedDiagnostic
             .Create(
-                DiagnosticRules.RuleIds.RequiresGodotRuntimeOnMethodId,
+                DiagnosticRules.RuleIds.REQUIRES_GODOT_RUNTIME_ON_METHOD_ID,
                 string.Format(
                     CultureInfo.InvariantCulture,
                     DiagnosticRules.GodotEngine.RequiresGodotRuntimeOnMethod.MessageFormat.ToString(),
@@ -80,7 +80,7 @@ public class GodotRuntimeRequireOnTestCaseAttributeTest
         var errorLine = new LinePosition(19, 12);
         var expected = ExpectedDiagnostic
             .Create(
-                DiagnosticRules.RuleIds.RequiresGodotRuntimeOnMethodId,
+                DiagnosticRules.RuleIds.REQUIRES_GODOT_RUNTIME_ON_METHOD_ID,
                 string.Format(
                     CultureInfo.InvariantCulture,
                     DiagnosticRules.GodotEngine.RequiresGodotRuntimeOnMethod.MessageFormat.ToString(),
@@ -119,7 +119,7 @@ public class GodotRuntimeRequireOnTestCaseAttributeTest
         // Both methods should trigger the diagnostic because they use Godot types
         var expectedA = ExpectedDiagnostic
             .Create(
-                DiagnosticRules.RuleIds.RequiresGodotRuntimeOnMethodId,
+                DiagnosticRules.RuleIds.REQUIRES_GODOT_RUNTIME_ON_METHOD_ID,
                 string.Format(
                     CultureInfo.InvariantCulture,
                     DiagnosticRules.GodotEngine.RequiresGodotRuntimeOnMethod.MessageFormat.ToString(),
@@ -128,7 +128,7 @@ public class GodotRuntimeRequireOnTestCaseAttributeTest
 
         var expectedB = ExpectedDiagnostic
             .Create(
-                DiagnosticRules.RuleIds.RequiresGodotRuntimeOnMethodId,
+                DiagnosticRules.RuleIds.REQUIRES_GODOT_RUNTIME_ON_METHOD_ID,
                 string.Format(
                     CultureInfo.InvariantCulture,
                     DiagnosticRules.GodotEngine.RequiresGodotRuntimeOnMethod.MessageFormat.ToString(),
@@ -159,7 +159,7 @@ public class GodotRuntimeRequireOnTestCaseAttributeTest
         // Both methods should trigger the diagnostic because they use Godot types
         var expectedA = ExpectedDiagnostic
             .Create(
-                DiagnosticRules.RuleIds.RequiresGodotRuntimeOnMethodId,
+                DiagnosticRules.RuleIds.REQUIRES_GODOT_RUNTIME_ON_METHOD_ID,
                 string.Format(
                     CultureInfo.InvariantCulture,
                     DiagnosticRules.GodotEngine.RequiresGodotRuntimeOnMethod.MessageFormat.ToString(),
@@ -186,7 +186,7 @@ public class GodotRuntimeRequireOnTestCaseAttributeTest
         // Both methods should trigger the diagnostic because they use Godot types
         var expectedA = ExpectedDiagnostic
             .Create(
-                DiagnosticRules.RuleIds.RequiresGodotRuntimeOnMethodId,
+                DiagnosticRules.RuleIds.REQUIRES_GODOT_RUNTIME_ON_METHOD_ID,
                 string.Format(
                     CultureInfo.InvariantCulture,
                     DiagnosticRules.GodotEngine.RequiresGodotRuntimeOnMethod.MessageFormat.ToString(),
@@ -266,7 +266,7 @@ public class GodotRuntimeRequireOnTestCaseAttributeTest
         var errorLine = new LinePosition(23, 12);
         var expected = ExpectedDiagnostic
             .Create(
-                DiagnosticRules.RuleIds.RequiresGodotRuntimeOnMethodId,
+                DiagnosticRules.RuleIds.REQUIRES_GODOT_RUNTIME_ON_METHOD_ID,
                 string.Format(
                     CultureInfo.InvariantCulture,
                     DiagnosticRules.GodotEngine.RequiresGodotRuntimeOnMethod.MessageFormat.ToString(),
@@ -297,7 +297,7 @@ public class GodotRuntimeRequireOnTestCaseAttributeTest
         var errorLine = new LinePosition(19, 12);
         var expected = ExpectedDiagnostic
             .Create(
-                DiagnosticRules.RuleIds.RequiresGodotRuntimeOnMethodId,
+                DiagnosticRules.RuleIds.REQUIRES_GODOT_RUNTIME_ON_METHOD_ID,
                 string.Format(
                     CultureInfo.InvariantCulture,
                     DiagnosticRules.GodotEngine.RequiresGodotRuntimeOnMethod.MessageFormat.ToString(),
@@ -359,7 +359,7 @@ public class GodotRuntimeRequireOnTestCaseAttributeTest
         var errorLine = new LinePosition(49, 12);
         var expected = ExpectedDiagnostic
             .Create(
-                DiagnosticRules.RuleIds.RequiresGodotRuntimeOnMethodId,
+                DiagnosticRules.RuleIds.REQUIRES_GODOT_RUNTIME_ON_METHOD_ID,
                 string.Format(
                     CultureInfo.InvariantCulture,
                     DiagnosticRules.GodotEngine.RequiresGodotRuntimeOnMethod.MessageFormat.ToString(),

--- a/Analyzers.Test/src/GodotRuntimeRequireOnTestHookAttributeTest.cs
+++ b/Analyzers.Test/src/GodotRuntimeRequireOnTestHookAttributeTest.cs
@@ -53,7 +53,7 @@ public class GodotRuntimeRequireOnTestHookAttributeTest
         var errorLine = new LinePosition(15, 17); // Position at the class level
         var expected = ExpectedDiagnostic
             .Create(
-                DiagnosticRules.RuleIds.RequiresGodotRuntimeOnClassId,
+                DiagnosticRules.RuleIds.REQUIRES_GODOT_RUNTIME_ON_CLASS_ID,
                 string.Format(
                     CultureInfo.InvariantCulture,
                     DiagnosticRules.GodotEngine.RequiresGodotRuntimeOnClass.MessageFormat.ToString(),
@@ -101,7 +101,7 @@ public class GodotRuntimeRequireOnTestHookAttributeTest
         var errorLine = new LinePosition(15, 17); // Position at the class level
         var expected = ExpectedDiagnostic
             .Create(
-                DiagnosticRules.RuleIds.RequiresGodotRuntimeOnClassId,
+                DiagnosticRules.RuleIds.REQUIRES_GODOT_RUNTIME_ON_CLASS_ID,
                 string.Format(
                     CultureInfo.InvariantCulture,
                     DiagnosticRules.GodotEngine.RequiresGodotRuntimeOnClass.MessageFormat.ToString(),
@@ -149,7 +149,7 @@ public class GodotRuntimeRequireOnTestHookAttributeTest
         var errorLine = new LinePosition(15, 17); // Position at the class level
         var expected = ExpectedDiagnostic
             .Create(
-                DiagnosticRules.RuleIds.RequiresGodotRuntimeOnClassId,
+                DiagnosticRules.RuleIds.REQUIRES_GODOT_RUNTIME_ON_CLASS_ID,
                 string.Format(
                     CultureInfo.InvariantCulture,
                     DiagnosticRules.GodotEngine.RequiresGodotRuntimeOnClass.MessageFormat.ToString(),
@@ -197,7 +197,7 @@ public class GodotRuntimeRequireOnTestHookAttributeTest
         var errorLine = new LinePosition(15, 17); // Position at the class level
         var expected = ExpectedDiagnostic
             .Create(
-                DiagnosticRules.RuleIds.RequiresGodotRuntimeOnClassId,
+                DiagnosticRules.RuleIds.REQUIRES_GODOT_RUNTIME_ON_CLASS_ID,
                 string.Format(
                     CultureInfo.InvariantCulture,
                     DiagnosticRules.GodotEngine.RequiresGodotRuntimeOnClass.MessageFormat.ToString(),
@@ -226,7 +226,7 @@ public class GodotRuntimeRequireOnTestHookAttributeTest
         var errorLine = new LinePosition(15, 17); // Position at the class level
         var expected = ExpectedDiagnostic
             .Create(
-                DiagnosticRules.RuleIds.RequiresGodotRuntimeOnClassId,
+                DiagnosticRules.RuleIds.REQUIRES_GODOT_RUNTIME_ON_CLASS_ID,
                 string.Format(
                     CultureInfo.InvariantCulture,
                     DiagnosticRules.GodotEngine.RequiresGodotRuntimeOnClass.MessageFormat.ToString(),

--- a/Analyzers/src/DiagnosticRules.cs
+++ b/Analyzers/src/DiagnosticRules.cs
@@ -25,17 +25,17 @@ internal static class DiagnosticRules
         /// <summary>
         ///     Rule ID for detecting when a method with a DataPoint attribute has multiple TestCase attributes.
         /// </summary>
-        public const string DataPointWithMultipleTestCase = "GdUnit0201";
+        public const string DATA_POINT_WITH_MULTIPLE_TEST_CASE = "GdUnit0201";
 
         /// <summary>
         ///     Rule ID for detecting when a test class using Godot functionality needs the RequireGodotRuntime attribute.
         /// </summary>
-        public const string RequiresGodotRuntimeOnClassId = "GdUnit0500";
+        public const string REQUIRES_GODOT_RUNTIME_ON_CLASS_ID = "GdUnit0500";
 
         /// <summary>
         ///     Rule ID for detecting when a test method using Godot functionality needs the RequireGodotRuntime attribute.
         /// </summary>
-        public const string RequiresGodotRuntimeOnMethodId = "GdUnit0501";
+        public const string REQUIRES_GODOT_RUNTIME_ON_METHOD_ID = "GdUnit0501";
     }
 
     /// <summary>
@@ -49,14 +49,14 @@ internal static class DiagnosticRules
         ///     DataPoint methods should only have a single TestCase attribute to avoid undefined behavior.
         /// </summary>
         public static readonly DiagnosticDescriptor MultipleTestCaseAttributes = new(
-            RuleIds.DataPointWithMultipleTestCase,
+            RuleIds.DATA_POINT_WITH_MULTIPLE_TEST_CASE,
             "Multiple TestCase attributes not allowed with DataPoint",
             "Method '{0}' cannot have multiple TestCase attributes when DataPoint attribute is present",
-            Categories.AttributeUsage,
+            Categories.ATTRIBUTE_USAGE,
             DiagnosticSeverity.Error,
             true,
             "Methods decorated with DataPoint attribute can only have one TestCase attribute. Multiple TestCase attributes on a method that uses DataPoint will result in undefined behavior.",
-            $"{HELP_LINK}/{RuleIds.DataPointWithMultipleTestCase}.md",
+            $"{HELP_LINK}/{RuleIds.DATA_POINT_WITH_MULTIPLE_TEST_CASE}.md",
             WellKnownDiagnosticTags.Compiler);
 
         // Future TestCase rules can be added here
@@ -73,10 +73,10 @@ internal static class DiagnosticRules
         ///     is missing the RequireGodotRuntime attribute.
         /// </summary>
         public static readonly DiagnosticDescriptor RequiresGodotRuntimeOnMethod = new(
-            RuleIds.RequiresGodotRuntimeOnMethodId,
+            RuleIds.REQUIRES_GODOT_RUNTIME_ON_METHOD_ID,
             "Godot Runtime Required for Test Method",
             "Test method '{0}' uses Godot functionality but is not annotated with `[RequireGodotRuntime]`",
-            Categories.AttributeUsage,
+            Categories.ATTRIBUTE_USAGE,
             DiagnosticSeverity.Error,
             true,
             """
@@ -86,7 +86,7 @@ internal static class DiagnosticRules
 
             Add `[RequireGodotRuntime]` to either test method or class level.
             """,
-            $"{HELP_LINK}/{RuleIds.RequiresGodotRuntimeOnMethodId}.md",
+            $"{HELP_LINK}/{RuleIds.REQUIRES_GODOT_RUNTIME_ON_METHOD_ID}.md",
             WellKnownDiagnosticTags.Compiler);
 
         /// <summary>
@@ -94,10 +94,10 @@ internal static class DiagnosticRules
         ///     is missing the RequireGodotRuntime attribute.
         /// </summary>
         public static readonly DiagnosticDescriptor RequiresGodotRuntimeOnClass = new(
-            RuleIds.RequiresGodotRuntimeOnClassId,
+            RuleIds.REQUIRES_GODOT_RUNTIME_ON_CLASS_ID,
             "Godot Runtime Required for Test Class",
             "Test class '{0}' uses Godot native types or calls in test hooks but is not annotated with `[RequireGodotRuntime]`",
-            Categories.AttributeUsage,
+            Categories.ATTRIBUTE_USAGE,
             DiagnosticSeverity.Error,
             true,
             """
@@ -107,7 +107,7 @@ internal static class DiagnosticRules
 
             Add `[RequireGodotRuntime]` to the test class level.
             """,
-            $"{HELP_LINK}/{RuleIds.RequiresGodotRuntimeOnClassId}.md",
+            $"{HELP_LINK}/{RuleIds.REQUIRES_GODOT_RUNTIME_ON_CLASS_ID}.md",
             WellKnownDiagnosticTags.Compiler);
     }
 
@@ -120,6 +120,6 @@ internal static class DiagnosticRules
         /// <summary>
         ///     Category for rules related to proper usage of attributes.
         /// </summary>
-        public const string AttributeUsage = "Attribute Usage";
+        public const string ATTRIBUTE_USAGE = "Attribute Usage";
     }
 }

--- a/Api/src/Assertions.cs
+++ b/Api/src/Assertions.cs
@@ -1,15 +1,11 @@
 // Copyright (c) 2025 Mike Schulze
 // MIT License - See LICENSE file in the repository root for full license text
-
 namespace GdUnit4;
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 
 using Asserts;
 
@@ -239,7 +235,7 @@ public static class Assertions
     /// <typeparam name="TValue">The type of values in the dictionary.</typeparam>
     /// <param name="current">The current dictionary value to verify.</param>
     /// <returns>An instance of IDictionaryAssert for further assertions.</returns>
-    public static IDictionaryAssert<TKey, TValue> AssertThat<[MustBeVariant] TKey, [MustBeVariant] TValue>(Godot.Collections.Dictionary<TKey, TValue>? current)
+    public static IDictionaryAssert<TKey, TValue> AssertThat<[MustBeVariant] TKey, [MustBeVariant] TValue>(Dictionary<TKey, TValue>? current)
         where TKey : notnull
         where TValue : notnull
         => new DictionaryAssert<TKey, TValue>(current);
@@ -467,7 +463,7 @@ public static class Assertions
 
         try
         {
-            await task.ConfigureAwait(true);
+            _ = await task.ConfigureAwait(true);
             return default;
         }
         catch (Exception e)
@@ -521,7 +517,7 @@ public static class Assertions
         where TNode : Node
     {
         if (autoFree)
-            AutoFree(node);
+            _ = AutoFree(node);
         var tree = Engine.GetMainLoop() as SceneTree;
         tree!.Root.AddChild(node);
         return node;

--- a/Api/src/ISceneRunner.cs
+++ b/Api/src/ISceneRunner.cs
@@ -3,9 +3,6 @@
 
 namespace GdUnit4;
 
-using System;
-using System.Threading.Tasks;
-
 using Api;
 
 using Asserts;
@@ -277,8 +274,8 @@ public interface ISceneRunner : IDisposable
         if (Scene().ProcessMode != Node.ProcessModeEnum.Disabled)
             Input.FlushBufferedEvents();
 
-        await SyncProcessFrame;
-        await SyncPhysicsFrame;
+        _ = await SyncProcessFrame;
+        _ = await SyncPhysicsFrame;
     }
 
     /// <summary>

--- a/Api/src/Utils.cs
+++ b/Api/src/Utils.cs
@@ -3,11 +3,7 @@
 
 namespace GdUnit4;
 
-using System;
 using System.Diagnostics;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Godot;
 
@@ -55,7 +51,7 @@ public static class Utils
     {
         var tempFolder = Path.Combine(GodotTempDir(), path);
         if (!new FileInfo(tempFolder).Exists)
-            Directory.CreateDirectory(tempFolder);
+            _ = Directory.CreateDirectory(tempFolder);
         return tempFolder;
     }
 

--- a/Api/src/asserts/AssertFailures.cs
+++ b/Api/src/asserts/AssertFailures.cs
@@ -3,10 +3,7 @@
 
 namespace GdUnit4.Asserts;
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 
 using Core.Extensions;
@@ -542,7 +539,7 @@ internal static class AssertFailures
         {
             object? key = entry.Key.UnboxVariant();
             object? value = entry.Value.UnboxVariant();
-            keyValues.Add($"{{{key.Formatted()}, {value.Formatted()}}}");
+            _ = keyValues.Add($"{{{key.Formatted()}, {value.Formatted()}}}");
         }
 
         var pairs = string.Join("; ", keyValues.ToArray());

--- a/Api/src/asserts/NumberAssert.cs
+++ b/Api/src/asserts/NumberAssert.cs
@@ -3,7 +3,6 @@
 
 namespace GdUnit4.Asserts;
 
-using System;
 using System.Numerics;
 
 #pragma warning disable CS1591, SA1600 // Missing XML comment for publicly visible type or member
@@ -112,7 +111,7 @@ public class NumberAssert<TValue> : AssertBase<TValue>, INumberAssert<TValue>
 
     public new INumberAssert<TValue> OverrideFailureMessage(string message)
     {
-        base.OverrideFailureMessage(message);
+        _ = base.OverrideFailureMessage(message);
         return this;
     }
 }

--- a/Api/src/asserts/ObjectAssert.cs
+++ b/Api/src/asserts/ObjectAssert.cs
@@ -44,7 +44,7 @@ public sealed class ObjectAssert : AssertBase<object>, IObjectAssert
 
     public new IObjectAssert OverrideFailureMessage(string message)
     {
-        base.OverrideFailureMessage(message);
+        _ = base.OverrideFailureMessage(message);
         return this;
     }
 }

--- a/Api/src/asserts/SignalAssert.cs
+++ b/Api/src/asserts/SignalAssert.cs
@@ -4,7 +4,6 @@
 namespace GdUnit4.Asserts;
 
 using System.Diagnostics;
-using System.Threading.Tasks;
 
 using Core.Execution.Exceptions;
 using Core.Signals;
@@ -24,8 +23,8 @@ public sealed class SignalAssert : AssertBase<GodotObject>, ISignalAssert
 
     public async Task<ISignalAssert> IsEmitted(string signal, params Variant[] args)
     {
-        IsNotNull();
-        IsSignalExists(signal);
+        _ = IsNotNull();
+        _ = IsSignalExists(signal);
 
         var lineNumber = new StackFrame(3, true).GetFileLineNumber();
         var isEmitted = await IsEmittedTask(signal, args).ConfigureAwait(true);
@@ -36,8 +35,8 @@ public sealed class SignalAssert : AssertBase<GodotObject>, ISignalAssert
 
     public async Task<ISignalAssert> IsNotEmitted(string signal, params Variant[] args)
     {
-        IsNotNull();
-        IsSignalExists(signal);
+        _ = IsNotNull();
+        _ = IsSignalExists(signal);
 
         var lineNumber = new StackFrame(3, true).GetFileLineNumber();
         var isEmitted = await IsEmittedTask(signal, args).ConfigureAwait(true);
@@ -48,7 +47,7 @@ public sealed class SignalAssert : AssertBase<GodotObject>, ISignalAssert
 
     public ISignalAssert IsSignalExists(string signal)
     {
-        IsNotNull();
+        _ = IsNotNull();
         if (!Current!.HasSignal(signal))
             ThrowTestFailureReport(AssertFailures.IsSignalExists(Current, signal), Current, signal);
         return this;
@@ -56,8 +55,8 @@ public sealed class SignalAssert : AssertBase<GodotObject>, ISignalAssert
 
     public ISignalAssert IsCountEmitted(int expectedCount, string signal, params Variant[] args)
     {
-        IsNotNull();
-        IsSignalExists(signal);
+        _ = IsNotNull();
+        _ = IsSignalExists(signal);
         var count = GodotSignalCollector.Instance.Count(Current!, signal, args);
         if (count != expectedCount)
             ThrowTestFailureReport($"Expecting emitted count is {expectedCount} but was {count}", Current, signal);

--- a/Api/src/asserts/StringAssert.cs
+++ b/Api/src/asserts/StringAssert.cs
@@ -3,8 +3,6 @@
 
 namespace GdUnit4.Asserts;
 
-using System;
-
 using Core.Extensions;
 
 #pragma warning disable CS1591, SA1600 // Missing XML comment for publicly visible type or member
@@ -138,7 +136,7 @@ public sealed class StringAssert : AssertBase<string>, IStringAssert
     public new IStringAssert OverrideFailureMessage(string message)
     {
         ArgumentException.ThrowIfNullOrEmpty(message);
-        base.OverrideFailureMessage(message);
+        _ = base.OverrideFailureMessage(message);
         return this;
     }
 }

--- a/Api/src/core/GdUnit4Settings.cs
+++ b/Api/src/core/GdUnit4Settings.cs
@@ -76,7 +76,7 @@ internal static class GdUnit4Settings
     public static void SetUpdateNotification(bool enable)
     {
         ProjectSettings.SetSetting(UPDATE_NOTIFICATION_ENABLED, enable);
-        ProjectSettings.Save();
+        _ = ProjectSettings.Save();
     }
 
     public static string GetLogPath()
@@ -86,7 +86,7 @@ internal static class GdUnit4Settings
     {
         ProjectSettings.SetSetting(STDOUT_ENABLE_TO_FILE, true);
         ProjectSettings.SetSetting(STDOUT_WRITE_TO_FILE, path);
-        ProjectSettings.Save();
+        _ = ProjectSettings.Save();
     }
 
     // the configured server connection timeout in ms

--- a/Api/src/core/GdUnit4TestEngine.cs
+++ b/Api/src/core/GdUnit4TestEngine.cs
@@ -3,13 +3,7 @@
 
 namespace GdUnit4.Core;
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Api;
 
@@ -106,7 +100,7 @@ internal sealed class GdUnit4TestEngine : ITestEngine
             try
             {
                 // Wait for tasks to complete cancellation
-                Task.WaitAll(tasks.ToArray(), TimeSpan.FromSeconds(2));
+                _ = Task.WaitAll(tasks.ToArray(), TimeSpan.FromSeconds(2));
             }
             catch (Exception ex)
             {
@@ -197,7 +191,7 @@ internal sealed class GdUnit4TestEngine : ITestEngine
             var godotRunner = new GodotRuntimeTestRunner(Logger, debuggerFramework, Settings);
             ActiveTestRunners.Add(godotRunner);
             godotRunner.RunAndWait(godotExecutorTestSuites, eventListener, cancellationToken);
-            ActiveTestRunners.Remove(godotRunner);
+            _ = ActiveTestRunners.Remove(godotRunner);
         }
 
         // Run tests that don't require Godot runtime
@@ -206,7 +200,7 @@ internal sealed class GdUnit4TestEngine : ITestEngine
             var directRunner = new DefaultTestRunner(Logger, Settings);
             ActiveTestRunners.Add(directRunner);
             directRunner.RunAndWait(directExecutorTestSuites, eventListener, cancellationToken);
-            ActiveTestRunners.Remove(directRunner);
+            _ = ActiveTestRunners.Remove(directRunner);
         }
     }
 

--- a/Api/src/core/GdUnitConsole.cs
+++ b/Api/src/core/GdUnitConsole.cs
@@ -3,8 +3,6 @@
 
 namespace GdUnit4.Core;
 
-using System;
-using System.Collections.Generic;
 using System.Drawing;
 
 internal sealed class GdUnitConsole
@@ -63,7 +61,7 @@ internal sealed class GdUnitConsole
         if (savedCursorsByName.TryGetValue(name, out var position))
         {
             Console.SetCursorPosition(position.Left, position.Top);
-            savedCursorsByName.Remove(name);
+            _ = savedCursorsByName.Remove(name);
         }
     }
 
@@ -109,7 +107,7 @@ internal sealed class GdUnitConsole
 
     private Color ToColor(ConsoleColor color)
     {
-        var colorName = Enum.GetName(typeof(ConsoleColor), color);
+        var colorName = Enum.GetName(color);
         return Color.FromName(colorName!);
     }
 

--- a/Api/src/core/GdUnitTestSuiteBuilder.cs
+++ b/Api/src/core/GdUnitTestSuiteBuilder.cs
@@ -3,11 +3,7 @@
 
 namespace GdUnit4.Core;
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
 
 using Godot;
 
@@ -68,7 +64,7 @@ internal static class GdUnitTestSuiteBuilder
             // create a directory if not exists
             var dir = Path.GetDirectoryName(testSuitePath);
             if (!Directory.Exists(dir))
-                Directory.CreateDirectory(dir!);
+                _ = Directory.CreateDirectory(dir!);
 
             if (!File.Exists(testSuitePath))
             {

--- a/Api/src/core/MouseMoveTask.cs
+++ b/Api/src/core/MouseMoveTask.cs
@@ -2,8 +2,7 @@
 // MIT License - See LICENSE file in the repository root for full license text
 namespace GdUnit4.Core;
 
-using System;
-using System.Threading.Tasks;
+using System.Diagnostics.CodeAnalysis;
 
 using Godot;
 
@@ -29,6 +28,10 @@ internal partial class MouseMoveTask : Node, IDisposable
         GC.SuppressFinalize(this);
     }
 
+    [SuppressMessage(
+        "Style",
+        "IDE0058:Expression value is never used",
+        Justification = "Method called for side effects only, return value intentionally ignored")]
     public async Task WaitOnFinalPosition(ISceneRunner sceneRunner, double time, Tween.TransitionType transitionType)
     {
         using var tween = sceneRunner.Scene().CreateTween();

--- a/Api/src/core/SceneRunner.cs
+++ b/Api/src/core/SceneRunner.cs
@@ -3,13 +3,7 @@
 
 namespace GdUnit4.Core;
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Api;
 
@@ -44,7 +38,7 @@ internal sealed class SceneRunner : ISceneRunner
         this.currentScene = currentScene;
         SceneTree.Root.AddChild(this.currentScene);
         SavedIterationsPerSecond = Engine.PhysicsTicksPerSecond;
-        SetTimeFactor();
+        _ = SetTimeFactor();
     }
 
     private SceneTree SceneTree { get; }
@@ -74,8 +68,8 @@ internal sealed class SceneRunner : ISceneRunner
 
     public ISceneRunner SimulateActionPressed(string action)
     {
-        SimulateActionPress(action);
-        SimulateActionRelease(action);
+        _ = SimulateActionPress(action);
+        _ = SimulateActionRelease(action);
         return this;
     }
 
@@ -86,7 +80,7 @@ internal sealed class SceneRunner : ISceneRunner
             Pressed = false,
             Action = action
         };
-        actionOnPress.Remove(action);
+        _ = actionOnPress.Remove(action);
         return HandleInputEvent(inputEvent);
     }
 
@@ -109,8 +103,8 @@ internal sealed class SceneRunner : ISceneRunner
 
     public ISceneRunner SimulateKeyPressed(Key keyCode, bool shift = false, bool control = false)
     {
-        SimulateKeyPress(keyCode, shift, control);
-        SimulateKeyRelease(keyCode, shift, control);
+        _ = SimulateKeyPress(keyCode, shift, control);
+        _ = SimulateKeyRelease(keyCode, shift, control);
         return this;
     }
 
@@ -127,7 +121,7 @@ internal sealed class SceneRunner : ISceneRunner
             CtrlPressed = controlPressed || keyCode == Key.Ctrl
         };
         ApplyInputModifiers(inputEvent);
-        keyOnPress.Remove(keyCode);
+        _ = keyOnPress.Remove(keyCode);
         return HandleInputEvent(inputEvent);
     }
 
@@ -177,8 +171,8 @@ internal sealed class SceneRunner : ISceneRunner
 
     public ISceneRunner SimulateMouseButtonPressed(MouseButton buttonIndex, bool doubleClick = false)
     {
-        SimulateMouseButtonPress(buttonIndex, doubleClick);
-        SimulateMouseButtonRelease(buttonIndex);
+        _ = SimulateMouseButtonPress(buttonIndex, doubleClick);
+        _ = SimulateMouseButtonRelease(buttonIndex);
         return this;
     }
 
@@ -207,7 +201,7 @@ internal sealed class SceneRunner : ISceneRunner
             Pressed = false
         };
 
-        mouseButtonOnPress.Remove(buttonIndex);
+        _ = mouseButtonOnPress.Remove(buttonIndex);
         ApplyInputMousePosition(inputEvent);
         ApplyInputMouseMask(inputEvent);
         ApplyInputModifiers(inputEvent);
@@ -237,7 +231,7 @@ internal sealed class SceneRunner : ISceneRunner
     {
         var timeShiftFrames = Math.Max(1, frames / TimeFactor);
         for (var frame = 0; frame <= timeShiftFrames; frame++)
-            await ISceneRunner.SyncProcessFrame;
+            _ = await ISceneRunner.SyncProcessFrame;
     }
 
     public Node Scene() => currentScene;
@@ -346,7 +340,7 @@ internal sealed class SceneRunner : ISceneRunner
         foreach (var button in mouseButtonOnPress)
         {
             if (Input.IsMouseButtonPressed(button))
-                SimulateMouseButtonRelease(button);
+                _ = SimulateMouseButtonRelease(button);
         }
 
         mouseButtonOnPress.Clear();
@@ -354,7 +348,7 @@ internal sealed class SceneRunner : ISceneRunner
         foreach (var key in keyOnPress)
         {
             if (Input.IsKeyPressed(key))
-                SimulateKeyRelease(key);
+                _ = SimulateKeyRelease(key);
         }
 
         keyOnPress.Clear();
@@ -362,7 +356,7 @@ internal sealed class SceneRunner : ISceneRunner
         foreach (var action in actionOnPress)
         {
             if (Input.IsActionPressed(action))
-                SimulateActionRelease(action);
+                _ = SimulateActionRelease(action);
         }
 
         actionOnPress.Clear();
@@ -411,16 +405,16 @@ internal sealed class SceneRunner : ISceneRunner
             Input.WarpMouse(mouseEvent.Position);
         Input.ParseInputEvent(inputEvent);
         if (inputEvent is InputEventAction actionEvent)
-            HandleActionEvent(actionEvent);
+            _ = HandleActionEvent(actionEvent);
         Input.FlushBufferedEvents();
 
         if (GodotObject.IsInstanceValid(currentScene))
         {
             Print($"	process event {currentScene} ({SceneName()}) <- {inputEvent.AsText()}");
             if (currentScene.HasMethod("_gui_input"))
-                currentScene.Call("_gui_input", inputEvent);
+                _ = currentScene.Call("_gui_input", inputEvent);
             if (currentScene.HasMethod("_unhandled_input"))
-                currentScene.Call("_unhandled_input", inputEvent);
+                _ = currentScene.Call("_unhandled_input", inputEvent);
             currentScene.GetViewport().SetInputAsHandled();
         }
 
@@ -509,7 +503,7 @@ internal sealed class SceneRunner : ISceneRunner
             => await Task.Run(async () =>
                 {
                     // sync to the main thread
-                    await GodotObjectExtensions.SyncProcessFrame;
+                    _ = await GodotObjectExtensions.SyncProcessFrame;
                     var value = await GodotObjectExtensions.Invoke(Instance, MethodName, Args).ConfigureAwait(true);
                     assertion(value);
                     return this;

--- a/Api/src/core/commands/ExecuteTestSuiteCommand.cs
+++ b/Api/src/core/commands/ExecuteTestSuiteCommand.cs
@@ -3,10 +3,7 @@
 
 namespace GdUnit4.Core.Commands;
 
-using System;
-using System.Linq;
 using System.Net;
-using System.Threading.Tasks;
 
 using Api;
 
@@ -71,7 +68,7 @@ internal class ExecuteTestSuiteCommand : BaseCommand
                     IsEngineMode);
                 context.IsCaptureStdOut = IsCaptureStdOut;
                 if (context.IsEngineMode)
-                    await GodotObjectExtensions.SyncProcessFrame;
+                    _ = await GodotObjectExtensions.SyncProcessFrame;
                 await new TestSuiteExecutionStage(testSuite)
                     .Execute(context)
                     .ConfigureAwait(true);

--- a/Api/src/core/execution/ExecutionStage.cs
+++ b/Api/src/core/execution/ExecutionStage.cs
@@ -3,15 +3,12 @@
 
 namespace GdUnit4.Core.Execution;
 
-using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 using Exceptions;
 
@@ -23,7 +20,7 @@ using Reporting;
 
 using static Api.ReportType;
 
-using Environment = System.Environment;
+using Environment = Environment;
 
 internal abstract class ExecutionStage<T> : IExecutionStage
 {
@@ -89,7 +86,7 @@ internal abstract class ExecutionStage<T> : IExecutionStage
                     .ConfigureAwait(true);
             }
 
-            ValidateForExpectedException(context);
+            _ = ValidateForExpectedException(context);
         }
         catch (ExecutionTimeoutException e)
         {
@@ -128,8 +125,9 @@ internal abstract class ExecutionStage<T> : IExecutionStage
             if (string.IsNullOrEmpty(stackFrame) || stackFrame.Contains("Microsoft.VisualStudio.TestTools", StringComparison.Ordinal))
                 continue;
 
-            result.Append(stackFrame);
-            result.Append(Environment.NewLine);
+            result = result
+                .Append(stackFrame)
+                .Append(Environment.NewLine);
         }
 
         return result.ToString();

--- a/Api/src/core/execution/GdUnit4RuntimeExecutorGodotBridge.cs
+++ b/Api/src/core/execution/GdUnit4RuntimeExecutorGodotBridge.cs
@@ -3,12 +3,7 @@
 
 namespace GdUnit4.Core.Execution;
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Api;
 
@@ -95,9 +90,9 @@ internal class GdUnit4TestEventListener : ITestEventListener
 
     public void PublishEvent(ITestEvent testEvent) => EmitTestEvent(testEvent as TestEvent);
 
-    private static Godot.Collections.Dictionary<Variant, Variant> ToGdUnitEventStatistics(IDictionary<TestEvent.StatisticKey, object> statistics)
+    private static Dictionary<Variant, Variant> ToGdUnitEventStatistics(IDictionary<TestEvent.StatisticKey, object> statistics)
     {
-        var converted = new Godot.Collections.Dictionary<Variant, Variant>();
+        var converted = new Dictionary<Variant, Variant>();
         foreach (var (key, value) in statistics)
             converted[key.ToString().ToLower().ToVariant()] = value.ToVariant();
         return converted;
@@ -125,6 +120,6 @@ internal class GdUnit4TestEventListener : ITestEventListener
             data.Add("reports", serializedReports);
         }
 
-        listener.Call(data);
+        _ = listener.Call(data);
     }
 }

--- a/Api/src/core/execution/GodotRuntimeExecutor.cs
+++ b/Api/src/core/execution/GodotRuntimeExecutor.cs
@@ -3,12 +3,9 @@
 
 namespace GdUnit4.Core.Execution;
 
-using System;
 using System.IO.Pipes;
 using System.Net;
 using System.Security.Principal;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Api;
 
@@ -33,7 +30,7 @@ using static Api.ReportType;
 internal sealed class GodotRuntimeExecutor : InOutPipeProxy<NamedPipeClientStream>, ICommandExecutor
 {
     public GodotRuntimeExecutor(ITestEngineLogger logger)
-        : base(new NamedPipeClientStream(".", PipeName, PipeDirection.InOut, PipeOptions.Asynchronous, TokenImpersonationLevel.Impersonation), logger)
+        : base(new NamedPipeClientStream(".", PIPE_NAME, PipeDirection.InOut, PipeOptions.Asynchronous, TokenImpersonationLevel.Impersonation), logger)
         => Logger.LogInfo("Starting GodotGdUnit4RestClient.");
 
     public async Task StartAsync()
@@ -55,7 +52,7 @@ internal sealed class GodotRuntimeExecutor : InOutPipeProxy<NamedPipeClientStrea
     {
         try
         {
-            await ExecuteCommand(new TerminateGodotInstanceCommand(), new NoInteractTestEventListener(), CancellationToken.None)
+            _ = await ExecuteCommand(new TerminateGodotInstanceCommand(), new NoInteractTestEventListener(), CancellationToken.None)
                 .ConfigureAwait(true);
 
             // Give server time to process shutdown

--- a/Api/src/core/execution/exceptions/TestFailedException.cs
+++ b/Api/src/core/execution/exceptions/TestFailedException.cs
@@ -3,7 +3,6 @@
 
 namespace GdUnit4.Core.Execution.Exceptions;
 
-using System;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text;
@@ -103,7 +102,7 @@ public sealed class TestFailedException : Exception
                 {
                     LineNumber = LineNumber == -1 ? frame.GetFileLineNumber() : LineNumber;
                     FileName ??= frame.GetFileName();
-                    stackFrames.Append(new StackTrace(frame));
+                    stackFrames = stackFrames.Append(new StackTrace(frame));
                 }
 
                 // end collect frames at test case attribute

--- a/Api/src/core/execution/monitoring/GodotExceptionMonitor.cs
+++ b/Api/src/core/execution/monitoring/GodotExceptionMonitor.cs
@@ -3,15 +3,10 @@
 
 namespace GdUnit4.Core.Execution.Monitoring;
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Text;
-using System.Threading.Tasks;
 
 using Exceptions;
 
@@ -19,7 +14,7 @@ using Extensions;
 
 using Godot;
 
-using FileAccess = System.IO.FileAccess;
+using FileAccess = FileAccess;
 
 internal class GodotExceptionMonitor
 {
@@ -56,7 +51,7 @@ internal class GodotExceptionMonitor
         {
             using var fileStream = new FileStream(godotLogFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using var reader = new StreamReader(fileStream);
-            fileStream.Seek(0, SeekOrigin.End);
+            _ = fileStream.Seek(0, SeekOrigin.End);
             eof = fileStream.Length;
         }
         catch (IOException ex)
@@ -73,7 +68,7 @@ internal class GodotExceptionMonitor
             return;
 
         // we need to wait the current Godot main tread has processed all nodes
-        await GodotObjectExtensions.SyncProcessFrame;
+        _ = await GodotObjectExtensions.SyncProcessFrame;
 
         try
         {
@@ -128,8 +123,8 @@ internal class GodotExceptionMonitor
                 var methodInfo = match.Groups[1].Value;
                 fileName = NormalizedPath(match.Groups[2].Value);
                 lineNumber = int.Parse(match.Groups[3].Value);
-                stackFrames.Append($"  at: {methodInfo} in {fileName}:line {lineNumber}");
-                stackFrames.AppendLine();
+                _ = stackFrames.Append($"  at: {methodInfo} in {fileName}:line {lineNumber}");
+                _ = stackFrames.AppendLine();
             }
         }
 
@@ -196,7 +191,7 @@ internal class GodotExceptionMonitor
             using var reader = new StreamReader(fileStream);
 
             // Seek to the last known position
-            fileStream.Seek(eof, SeekOrigin.Begin);
+            _ = fileStream.Seek(eof, SeekOrigin.Begin);
 
             var records = new List<string>();
             while (reader.ReadLine() is { } line)

--- a/Api/src/core/execution/monitoring/MemoryPool.cs
+++ b/Api/src/core/execution/monitoring/MemoryPool.cs
@@ -3,10 +3,6 @@
 
 namespace GdUnit4.Core.Execution.Monitoring;
 
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-
 using Extensions;
 
 using Godot;
@@ -46,7 +42,7 @@ internal class MemoryPool
         currentPool?.registeredObjects.Clear();
         StopMonitoring();
         if (OrphanMonitor != null)
-            await GodotObjectExtensions.SyncProcessFrame;
+            _ = await GodotObjectExtensions.SyncProcessFrame;
     }
 
     public void StopMonitoring() => OrphanMonitor?.Stop();

--- a/Api/src/core/hooks/IStdOutHook.cs
+++ b/Api/src/core/hooks/IStdOutHook.cs
@@ -35,7 +35,7 @@ using Godot;
 ///     </para>
 /// </remarks>
 /// <seealso cref="Console" />
-/// <seealso cref="System.IO.TextWriter" />
+/// <seealso cref="TextWriter" />
 /// <seealso cref="GD.PrintS" />
 internal interface IStdOutHook : IDisposable
 {

--- a/Api/src/core/hooks/UnixStdOutHook.cs
+++ b/Api/src/core/hooks/UnixStdOutHook.cs
@@ -3,11 +3,9 @@
 
 namespace GdUnit4.Core.Hooks;
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading;
 
 [SuppressMessage("Style", "IDE1006", Justification = "Unix system call names follow C naming conventions")]
 [SuppressMessage(
@@ -53,6 +51,7 @@ internal sealed class UnixStdOutHook : IStdOutHook
             throw new InvalidOperationException($"Failed to create fcntl. Error: {hResult}");
     }
 
+    [SuppressMessage("Style", "IDE0058:Expression value is never used", Justification = "Method called for side effects only, return value intentionally ignored")]
     public void Dispose()
     {
         StopCapture();
@@ -79,6 +78,7 @@ internal sealed class UnixStdOutHook : IStdOutHook
         readThread.Start();
     }
 
+    [SuppressMessage("Style", "IDE0058:Expression value is never used", Justification = "Method called for side effects only, return value intentionally ignored")]
     public void StopCapture()
     {
         stdOutHook.StopCapture();

--- a/Api/src/core/hooks/WindowsStdOutHook.cs
+++ b/Api/src/core/hooks/WindowsStdOutHook.cs
@@ -3,11 +3,9 @@
 
 namespace GdUnit4.Core.Hooks;
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading;
 
 using Microsoft.Win32.SafeHandles;
 
@@ -69,7 +67,7 @@ internal sealed class WindowsStdOutHook : IStdOutHook
         readThread = null;
 
         // Restore original stdout
-        SetStdHandle(STD_OUTPUT_HANDLE, originalStdOutHandle);
+        _ = SetStdHandle(STD_OUTPUT_HANDLE, originalStdOutHandle);
     }
 
     public string GetCapturedOutput() => stdOutHook.GetCapturedOutput();
@@ -93,7 +91,7 @@ internal sealed class WindowsStdOutHook : IStdOutHook
             // Dispose unmanaged resources
             if (readEvent != IntPtr.Zero)
             {
-                CloseHandle(readEvent);
+                _ = CloseHandle(readEvent);
                 readEvent = IntPtr.Zero;
             }
 

--- a/Api/src/core/runners/GodotGdUnit4RestServer.cs
+++ b/Api/src/core/runners/GodotGdUnit4RestServer.cs
@@ -3,12 +3,8 @@
 
 namespace GdUnit4.Core.Runners;
 
-using System;
-using System.IO;
 using System.IO.Pipes;
 using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Api;
 
@@ -23,7 +19,7 @@ internal sealed class GodotGdUnit4RestServer : InOutPipeProxy<NamedPipeServerStr
     private readonly SemaphoreSlim processLock = new(1, 1);
 
     public GodotGdUnit4RestServer(ITestEngineLogger logger)
-        : base(new NamedPipeServerStream(PipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous), logger)
+        : base(new NamedPipeServerStream(PIPE_NAME, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous), logger)
         => Logger.LogInfo("GodotGdUnit4RestApi:: Starting GdUnit4 RestApi Server.");
 
     public bool IsFailed { get; set; }
@@ -51,7 +47,7 @@ internal sealed class GodotGdUnit4RestServer : InOutPipeProxy<NamedPipeServerStr
         if (!IsConnected)
             return;
 
-        await GodotObjectExtensions.SyncProcessFrame;
+        _ = await GodotObjectExtensions.SyncProcessFrame;
         if (!await processLock
                 .WaitAsync(TimeSpan.FromSeconds(1))
                 .ConfigureAwait(true))
@@ -85,7 +81,7 @@ internal sealed class GodotGdUnit4RestServer : InOutPipeProxy<NamedPipeServerStr
         }
         finally
         {
-            processLock.Release();
+            _ = processLock.Release();
         }
     }
 
@@ -109,7 +105,7 @@ internal sealed class GodotGdUnit4RestServer : InOutPipeProxy<NamedPipeServerStr
             }
             finally
             {
-                processLock.Release();
+                _ = processLock.Release();
             }
         }
         else

--- a/Api/src/core/runners/GodotRuntimeTestRunner.cs
+++ b/Api/src/core/runners/GodotRuntimeTestRunner.cs
@@ -3,20 +3,16 @@
 
 namespace GdUnit4.Core.Runners;
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using System.Reflection;
 using System.Text;
-using System.Threading;
 
 using Api;
 
 using Execution;
 
-using Environment = System.Environment;
+using Environment = Environment;
 
 /// <summary>
 ///     Test runner implementation that executes tests in a separate Godot runtime process.
@@ -95,7 +91,7 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
         lock (ProcessLock)
         {
             process?.Kill(true);
-            process?.WaitForExit(1000);
+            _ = process?.WaitForExit(1000);
             CloseProcess(process);
         }
     }
@@ -136,16 +132,16 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
                 };
                 process.ErrorDataReceived += StdErrorProcessor;
                 process.Exited += ExitHandler("GdUnit4 Godot Runtime Test Runner");
-                process.Start();
+                _ = process.Start();
                 process.BeginErrorReadLine();
                 process.BeginOutputReadLine();
                 if (DebuggerFramework.IsDebugAttach)
-                    DebuggerFramework.AttachDebuggerToProcess(process);
+                    _ = DebuggerFramework.AttachDebuggerToProcess(process);
             }
 
             base.RunAndWait(testSuiteNodes, eventListener, cancellationToken);
 
-            process.WaitForExit(2000);
+            _ = process.WaitForExit(2000);
 
             // wait until the process has finished
             var waitRetry = 0;
@@ -167,7 +163,7 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
     {
         var destinationFolderPath = Path.Combine(workingDirectory, @$"{TEMP_TEST_RUNNER_DIR}");
         if (!Directory.Exists(destinationFolderPath))
-            Directory.CreateDirectory(destinationFolderPath);
+            _ = Directory.CreateDirectory(destinationFolderPath);
 
         var sceneRunnerSource = Path.Combine(destinationFolderPath, "GdUnit4TestRunnerScene.cs");
 
@@ -232,7 +228,7 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
 
             compileProcess.BeginErrorReadLine();
             compileProcess.BeginOutputReadLine();
-            compileProcess.WaitForExit(100);
+            _ = compileProcess.WaitForExit(100);
 
             // The compile project can take a while, and we need to wait until it finishes
             // Calculate how many iterations we need based on the compile process timeout

--- a/Api/src/core/runners/InOutPipeProxy.cs
+++ b/Api/src/core/runners/InOutPipeProxy.cs
@@ -3,14 +3,10 @@
 
 namespace GdUnit4.Core.Runners;
 
-using System;
 using System.Buffers.Binary;
-using System.IO;
 using System.IO.Pipes;
 using System.Net;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Api;
 
@@ -21,7 +17,7 @@ using Newtonsoft.Json;
 internal class InOutPipeProxy<TPipe> : IAsyncDisposable
     where TPipe : PipeStream
 {
-    protected const string PipeName = "gdunit4-message-pipe";
+    protected const string PIPE_NAME = "gdunit4-message-pipe";
 
     protected InOutPipeProxy(TPipe pipe, ITestEngineLogger logger)
     {

--- a/Api/src/core/signals/GodotSignalCollector.cs
+++ b/Api/src/core/signals/GodotSignalCollector.cs
@@ -3,18 +3,14 @@
 
 namespace GdUnit4.Core.Signals;
 
-using System;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Extensions;
 
 using Godot;
 
-using static System.Console;
+using static Console;
 
 using Array = Godot.Collections.Array;
 using Error = Godot.Error;
@@ -67,9 +63,9 @@ internal sealed partial class GodotSignalCollector : RefCounted
                         {
                             Thread.Sleep(sleepTimeInMs);
                             if (isProcess && IsInstanceValid(emitter))
-                                emitter.CallDeferred("_Process", sleepTimeInMs);
+                                _ = emitter.CallDeferred("_Process", sleepTimeInMs);
                             if (isPhysicsProcess && IsInstanceValid(emitter))
-                                emitter.CallDeferred("_PhysicsProcess", sleepTimeInMs);
+                                _ = emitter.CallDeferred("_PhysicsProcess", sleepTimeInMs);
 
                             // ReSharper disable once AccessToDisposedClosure
                             if (signalCancellationToken.IsCancellationRequested)
@@ -119,7 +115,7 @@ internal sealed partial class GodotSignalCollector : RefCounted
             if (error != Error.Ok)
                 WriteLine($"Error on connecting signal {signalName}, Error: {error}");
 
-            emitterSignals.TryAdd(signalName, new ConcurrentBag<Variant[]>());
+            _ = emitterSignals.TryAdd(signalName, new ConcurrentBag<Variant[]>());
         }
     }
 
@@ -167,7 +163,7 @@ internal sealed partial class GodotSignalCollector : RefCounted
         }
 
         if (IsInstanceValid(emitter))
-            CollectedSignals.TryRemove(emitter, out _);
+            _ = CollectedSignals.TryRemove(emitter, out _);
 
         // DebugSignalList("UnregisterEmitter");
     }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,20 +2,27 @@
   <!--
   This Directory.Build.props file applies settings to all projects in this directory and subdirectories.
   It ensures consistent code quality, style, and build configuration across the entire solution.
-  For a GdUnit4Net project, these settings help maintain high-quality test code.
+  Updated for C# 12 support and GdUnit4Net project requirements.
   -->
 
   <PropertyGroup>
+    <!--
+    Language and Framework Configuration:
+    Set target framework and language version for modern C# features
+    -->
+    <LangVersion>12.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+
     <!--
     Analyzer Configuration:
     These settings enable code analysis tools that help maintain code quality by
     identifying potential issues, enforcing consistent style, and encouraging best practices.
     -->
 
-    <!-- Enable built-in .NET code analyzers -->
+    <!-- Enable built-in .NET code analyzers with latest rules -->
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
-
-    <AnalysisLevel>8.0</AnalysisLevel>
+    <AnalysisLevel>latest</AnalysisLevel>
 
     <!-- Enable all categories of analysis rules (Style, Design, Documentation, etc.) -->
     <AnalysisMode>All</AnalysisMode>
@@ -23,6 +30,7 @@
     <!-- Enforce code style rules during build, not just in the IDE -->
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 
+    <!-- Use the custom StyleCop ruleset -->
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)stylecop.ruleset</CodeAnalysisRuleSet>
 
     <!-- Convert all warnings to errors for stricter enforcement -->
@@ -33,14 +41,63 @@
     This enables full analyzer functionality and documents your test examples
     -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!--
+    MSBuild and Build Performance:
+    Enable features that improve build performance and developer experience
+    -->
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+
+    <!--
+    File Header Configuration:
+    Configure copyright header template for automatic insertion
+    -->
+    <FileHeaderTemplate>Copyright (c) $([System.DateTime]::Now.Year) Mike Schulze
+      MIT License - See LICENSE file in the repository root for full license text</FileHeaderTemplate>
+
+    <!-- Additional file header properties for better IDE integration -->
+    <EnableFileHeaderGeneration>true</EnableFileHeaderGeneration>
+    <FileHeaderCompany>Mike Schulze</FileHeaderCompany>
+    <FileHeaderCopyright>Copyright (c) $([System.DateTime]::Now.Year) Mike Schulze</FileHeaderCopyright>
+    <FileHeaderLicense>MIT License - See LICENSE file in the repository root for full license text</FileHeaderLicense>
+
+    <!--
+    Assembly and Package Metadata:
+    Default values for all projects in the solution
+    -->
+    <Company>Mike Schulze</Company>
+    <Copyright>Copyright (c) 2025 Mike Schulze</Copyright>
+    <Product>GdUnit4Net</Product>
+
   </PropertyGroup>
+
+  <!--
+  Configure source roots for projects with src folders
+  This tells the IDE and tooling that 'src' is the namespace root
+  -->
+  <ItemGroup Condition="Exists('$(MSBuildProjectDirectory)/src')">
+    <!-- Mark src folder as source root for namespace calculation -->
+    <SourceRoot Include="$(MSBuildProjectDirectory)/src/"/>
+  </ItemGroup>
+
+  <!--
+  Configure source roots for test projects
+  Test folders are also treated as namespace roots, typically with .Tests suffix
+  -->
+  <ItemGroup Condition="Exists('$(MSBuildProjectDirectory)/test') OR Exists('$(MSBuildProjectDirectory)/tests')">
+    <!-- Mark test folder as source root for namespace calculation -->
+    <SourceRoot Include="$(MSBuildProjectDirectory)/test/" Condition="Exists('$(MSBuildProjectDirectory)/test')"/>
+    <SourceRoot Include="$(MSBuildProjectDirectory)/tests/" Condition="Exists('$(MSBuildProjectDirectory)/tests')"/>
+  </ItemGroup>
 
   <!--
   External Code Analyzers:
   These packages provide additional rules beyond what's built into the .NET SDK.
   They're configured as private assets so they don't get published with your assembly.
+  Note: Analyzer projects (like GdUnit4Analyzers) are excluded as they manage their own analyzer dependencies.
   -->
-  <ItemGroup>
+  <ItemGroup Condition="!$(MSBuildProjectName.Contains('Analyzer'))">
+
     <!--
     StyleCop.Analyzers: Enforces style and consistency rules
     Helps ensure readable and maintainable code across the codebase
@@ -50,8 +107,51 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
 
-    <!-- Required for stylecop.json configuration file to work -->
-    <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json"/>
+    <!--
+    Microsoft.CodeAnalysis.Analyzers: Additional code quality rules
+    Provides enhanced analysis for modern C# patterns
+    -->
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
 
   </ItemGroup>
+
+  <!--
+  Configuration files for all projects
+  -->
+  <ItemGroup>
+    <!-- Configuration files for StyleCop -->
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json"/>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory).editorconfig"/>
+  </ItemGroup>
+
+  <!--
+  Conditional Configuration:
+  Different settings for different build configurations
+  -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <!-- Enable more detailed debugging information in Debug builds -->
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <!-- Optimize Release builds but keep debugging symbols -->
+    <DebugType>portable</DebugType>
+    <Optimize>true</Optimize>
+    <TrimUnusedDependencies>true</TrimUnusedDependencies>
+  </PropertyGroup>
+
+  <!--
+  Test Project Specific Configuration:
+  Relaxed rules for test projects to allow more flexible coding patterns
+  -->
+  <PropertyGroup Condition="$(MSBuildProjectName.Contains('Test'))">
+    <!-- Test projects can be more lenient with some rules -->
+    <NoWarn>$(NoWarn);CA1515;CA1822</NoWarn>
+  </PropertyGroup>
+
 </Project>

--- a/TestAdapter.Test/test/NoOpLogger.cs
+++ b/TestAdapter.Test/test/NoOpLogger.cs
@@ -2,7 +2,7 @@ namespace GdUnit4.TestAdapter.Test;
 
 using Api;
 
-public sealed class NoOpLogger : ITestEngineLogger
+internal sealed class NoOpLogger : ITestEngineLogger
 {
     public void SendMessage(LogLevel logLevel, string message)
     {

--- a/TestAdapter.Test/test/TestUtils.cs
+++ b/TestAdapter.Test/test/TestUtils.cs
@@ -1,9 +1,6 @@
 namespace GdUnit4.TestAdapter.Test;
 
-using System;
-using System.IO;
-
-public static class TestUtils
+internal static class TestUtils
 {
     public static string GetResourcePath(string resourcePath)
     {

--- a/TestAdapter.Test/test/discovery/GdUnit4TestDiscovererTest.cs
+++ b/TestAdapter.Test/test/discovery/GdUnit4TestDiscovererTest.cs
@@ -1,10 +1,5 @@
 namespace GdUnit4.TestAdapter.Test.Discovery;
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-
 using Api;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -52,10 +47,10 @@ public class GdUnit4TestDiscovererTest
 
         // Setup mock RunContext with RunSettings
         var mockRunContext = new Mock<IRunContext>();
-        mockRunContext.SetupGet(rc => rc.RunSettings)
+        _ = mockRunContext.SetupGet(rc => rc.RunSettings)
             .Returns(Mock.Of<IRunSettings>(rs => rs.SettingsXml == XML_SETTINGS));
 
-        // Check initial state
+        // Check the initial state
         var assemblyPath = GetExampleAssemblyPath();
         Assert.IsFalse(IsAssemblyLoaded(assemblyPath), "Assembly should not be loaded initially");
 
@@ -70,20 +65,20 @@ public class GdUnit4TestDiscovererTest
         var frameworkHandle = new Mock<IFrameworkHandle>();
         var logMessages = new List<string>();
 
-        frameworkHandle
+        _ = frameworkHandle
             .Setup(logger => logger.SendMessage(It.IsAny<TestMessageLevel>(), It.IsAny<string>()))
             .Callback<TestMessageLevel, string>((level, message) => logMessages.Add($"{level}: {message}"));
 
         // Setup the mock to capture discovered tests
         var mockDiscoverySink = new Mock<ITestCaseDiscoverySink>();
         var discoveredTests = new List<TestCase>();
-        mockDiscoverySink
+        _ = mockDiscoverySink
             .Setup(ds => ds.SendTestCase(It.IsAny<TestCase>()))
             .Callback<TestCase>(discoveredTests.Add);
 
         // Setup mock RunContext with RunSettings
         var mockRunContext = new Mock<IRunContext>();
-        mockRunContext.SetupGet(rc => rc.RunSettings)
+        _ = mockRunContext.SetupGet(rc => rc.RunSettings)
             .Returns(Mock.Of<IRunSettings>(rs => rs.SettingsXml == XML_SETTINGS));
 
         // the first one should be excluded because it is 'TestAdapter' in the name
@@ -118,20 +113,20 @@ public class GdUnit4TestDiscovererTest
         var frameworkHandle = new Mock<IFrameworkHandle>();
         var logMessages = new List<string>();
 
-        frameworkHandle
+        _ = frameworkHandle
             .Setup(logger => logger.SendMessage(It.IsAny<TestMessageLevel>(), It.IsAny<string>()))
             .Callback<TestMessageLevel, string>((level, message) => logMessages.Add($"{level}: {message}"));
 
         // Setup the mock to capture discovered tests
         var mockDiscoverySink = new Mock<ITestCaseDiscoverySink>();
         var discoveredTests = new List<TestCase>();
-        mockDiscoverySink
+        _ = mockDiscoverySink
             .Setup(ds => ds.SendTestCase(It.IsAny<TestCase>()))
             .Callback<TestCase>(discoveredTests.Add);
 
         // Setup mock RunContext with RunSettings
         var mockRunContext = new Mock<IRunContext>();
-        mockRunContext.SetupGet(rc => rc.RunSettings)
+        _ = mockRunContext.SetupGet(rc => rc.RunSettings)
             .Returns(Mock.Of<IRunSettings>(rs => rs.SettingsXml == XML_SETTINGS));
 
         // var assemblyPath = "D:\\development\\workspace\\gdUnit4Net\\test\\.godot\\mono\\temp\\bin\\Debug\\gdUnit4Test.dll"; //AssemblyPaths.LibraryPath;
@@ -224,7 +219,7 @@ public class GdUnit4TestDiscovererTest
         Assert.IsNotNull(test.Id);
         Assert.AreEqual(fullyQualifiedName, test.FullyQualifiedName);
         Assert.AreEqual(displayName, test.DisplayName);
-        Assert.AreEqual(new Uri(GdUnit4TestExecutor.ExecutorUri), test.ExecutorUri);
+        Assert.AreEqual(new Uri(GdUnit4TestExecutor.EXECUTOR_URI), test.ExecutorUri);
         Assert.AreEqual(source, test.Source);
         var expectedPath = codeFilePath.Replace('\\', Path.DirectorySeparatorChar);
         var actualPath = test.CodeFilePath?.Replace('\\', Path.DirectorySeparatorChar);

--- a/TestAdapter.Test/test/execution/GdUnit4TestExecutorTest.cs
+++ b/TestAdapter.Test/test/execution/GdUnit4TestExecutorTest.cs
@@ -1,7 +1,5 @@
 namespace GdUnit4.TestAdapter.Test.Execution;
 
-using System;
-
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -48,7 +46,7 @@ public class GdUnit4TestExecutorTest
 
         // Setup mock RunContext with RunSettings
         var mockRunContext = new Mock<IRunContext>();
-        mockRunContext.SetupGet(rc => rc.RunSettings)
+        _ = mockRunContext.SetupGet(rc => rc.RunSettings)
             .Returns(Mock.Of<IRunSettings>(rs => rs.SettingsXml == XML_SETTINGS));
 
         // run

--- a/TestAdapter.Test/test/execution/TestCaseFilterTest.cs
+++ b/TestAdapter.Test/test/execution/TestCaseFilterTest.cs
@@ -1,9 +1,6 @@
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
 namespace GdUnit4.TestAdapter.Test.Execution;
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 using Api;
@@ -167,7 +164,7 @@ public class TestCaseFilterTest
     [TestMethod]
     public void GetPropertyValueTestCategoryAsProperty()
     {
-        var test = new TestCase("Test1", new Uri(GdUnit4TestExecutor.ExecutorUri), "GdUnit4Net");
+        var test = new TestCase("Test1", new Uri(GdUnit4TestExecutor.EXECUTOR_URI), "GdUnit4Net");
         test.SetPropertyValue(TestCaseExtensions.TestCategoryProperty, new[] { "CategoryA", "CategoryB" });
         var value = test.GetPropertyValue("TestCategory") as string[];
 

--- a/TestAdapter.Test/test/utilities/UtilsTest.cs
+++ b/TestAdapter.Test/test/utilities/UtilsTest.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using static TestAdapter.Utilities.Utils;
 
-using Environment = System.Environment;
+using Environment = Environment;
 
 [TestClass]
 public class UtilsTest

--- a/TestAdapter/src/GdUnit4TestDiscoverer.cs
+++ b/TestAdapter/src/GdUnit4TestDiscoverer.cs
@@ -3,10 +3,7 @@
 
 namespace GdUnit4.TestAdapter;
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 
 using Api;
 
@@ -38,8 +35,8 @@ using TestCaseDescriptor = Core.Discovery.TestCaseDescriptor;
 ///     The class is decorated with VSTest adapter attributes that register it as a test discoverer
 ///     for .dll and .exe files in the managed code category.
 /// </remarks>
-[DefaultExecutorUri(GdUnit4TestExecutor.ExecutorUri)]
-[ExtensionUri(GdUnit4TestExecutor.ExecutorUri)]
+[DefaultExecutorUri(GdUnit4TestExecutor.EXECUTOR_URI)]
+[ExtensionUri(GdUnit4TestExecutor.EXECUTOR_URI)]
 [FileExtension(".dll")]
 [FileExtension(".exe")]
 [Category("managed")]
@@ -154,7 +151,7 @@ public sealed class GdUnit4TestDiscoverer : ITestDiscoverer
     /// </remarks>
     internal static TestCase BuildTestCase(TestCaseDescriptor descriptor, GdUnit4Settings settings)
     {
-        TestCase testCase = new(descriptor.FullyQualifiedName, new Uri(GdUnit4TestExecutor.ExecutorUri), descriptor.AssemblyPath)
+        TestCase testCase = new(descriptor.FullyQualifiedName, new Uri(GdUnit4TestExecutor.EXECUTOR_URI), descriptor.AssemblyPath)
         {
             Id = descriptor.Id,
             DisplayName = GetDisplayName(descriptor, settings),

--- a/TestAdapter/src/GdUnit4TestExecutor.cs
+++ b/TestAdapter/src/GdUnit4TestExecutor.cs
@@ -3,9 +3,6 @@
 
 namespace GdUnit4.TestAdapter;
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Xml;
 
 using Api;
@@ -43,13 +40,13 @@ using Utilities;
 ///     The executor works in conjunction with the discoverer to provide a complete
 ///     VSTest adapter implementation that bridges GdUnit4 tests with the VSTest platform.
 /// </remarks>
-[ExtensionUri(ExecutorUri)]
+[ExtensionUri(EXECUTOR_URI)]
 public class GdUnit4TestExecutor : ITestExecutor2, IDisposable
 {
     /// <summary>
     ///     The Uri used to identify the GdUnit4 Executor.
     /// </summary>
-    public const string ExecutorUri = "executor://GdUnit4.TestAdapter";
+    public const string EXECUTOR_URI = "executor://GdUnit4.TestAdapter";
 
     /// <summary>
     ///     The default test session timeout is set to 10min (600000ms).

--- a/TestAdapter/src/extensions/StringExtensions.cs
+++ b/TestAdapter/src/extensions/StringExtensions.cs
@@ -3,8 +3,6 @@
 
 namespace GdUnit4.TestAdapter.Extensions;
 
-using System;
-using System.Linq;
 using System.Text;
 
 using Api;
@@ -36,12 +34,12 @@ internal static class StringExtensions
         switch (reportType)
         {
             case Stdout:
-                sb.AppendLine($"{ANSI_BLUE}{ANSI_BOLD}Standard Output: {ANSI_ITALIC}{ANSI_RESET}");
-                sb.AppendLine($"{ANSI_BLUE}──────────────────────────────────────────{ANSI_RESET}");
+                _ = sb.AppendLine($"{ANSI_BLUE}{ANSI_BOLD}Standard Output: {ANSI_ITALIC}{ANSI_RESET}");
+                _ = sb.AppendLine($"{ANSI_BLUE}──────────────────────────────────────────{ANSI_RESET}");
 
                 break;
             case Warning:
-                sb.AppendLine($"{ANSI_YELLOW}{ANSI_BOLD}Warning:{ANSI_ITALIC}{ANSI_RESET}");
+                _ = sb.AppendLine($"{ANSI_YELLOW}{ANSI_BOLD}Warning:{ANSI_ITALIC}{ANSI_RESET}");
 
                 break;
             case Success:
@@ -55,7 +53,7 @@ internal static class StringExtensions
                 break;
         }
 
-        sb
+        _ = sb
             .Append(message)
             .Append(Environment.NewLine);
         return sb.ToString();

--- a/TestAdapter/src/settings/GdUnit4Settings.cs
+++ b/TestAdapter/src/settings/GdUnit4Settings.cs
@@ -3,7 +3,6 @@
 
 namespace GdUnit4.TestAdapter.Settings;
 
-using System.IO;
 using System.Xml;
 using System.Xml.Serialization;
 
@@ -49,13 +48,13 @@ public enum DisplayNameOptions
 ///     - Compilation timeout for projects that require extended build times
 ///     These settings are loaded by <see cref="GdUnit4SettingsProvider" /> during test discovery and execution.
 /// </remarks>
-[XmlRoot(RunSettingsXmlNode)]
+[XmlRoot(RUN_SETTINGS_XML_NODE)]
 public class GdUnit4Settings : TestRunSettings
 {
     /// <summary>
     ///     The XML node name used to identify GdUnit4 settings in .runsettings files.
     /// </summary>
-    public const string RunSettingsXmlNode = "GdUnit4";
+    public const string RUN_SETTINGS_XML_NODE = "GdUnit4";
 
     private static readonly XmlSerializer Serializer = new(typeof(GdUnit4Settings));
 
@@ -63,7 +62,7 @@ public class GdUnit4Settings : TestRunSettings
     ///     Initializes a new instance of the <see cref="GdUnit4Settings" /> class.
     /// </summary>
     public GdUnit4Settings()
-        : base(RunSettingsXmlNode)
+        : base(RUN_SETTINGS_XML_NODE)
     {
     }
 

--- a/TestAdapter/src/settings/GdUnit4SettingsProvider.cs
+++ b/TestAdapter/src/settings/GdUnit4SettingsProvider.cs
@@ -3,14 +3,13 @@
 
 namespace GdUnit4.TestAdapter.Settings;
 
-using System;
 using System.Xml;
 using System.Xml.Serialization;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
-[SettingsName(GdUnit4Settings.RunSettingsXmlNode)]
+[SettingsName(GdUnit4Settings.RUN_SETTINGS_XML_NODE)]
 
 // ReSharper disable once ClassNeverInstantiated.Global
 internal sealed class GdUnit4SettingsProvider : ISettingsProvider
@@ -23,7 +22,7 @@ internal sealed class GdUnit4SettingsProvider : ISettingsProvider
     {
         try
         {
-            if (reader.Read() && reader.Name == GdUnit4Settings.RunSettingsXmlNode)
+            if (reader.Read() && reader.Name == GdUnit4Settings.RUN_SETTINGS_XML_NODE)
             {
                 var settings = Serializer.Deserialize(reader) as GdUnit4Settings;
                 Settings = settings ?? new GdUnit4Settings();
@@ -39,7 +38,7 @@ internal sealed class GdUnit4SettingsProvider : ISettingsProvider
 
     internal static GdUnit4Settings LoadSettings(IDiscoveryContext discoveryContext)
     {
-        var gdUnitSettingsProvider = discoveryContext.RunSettings?.GetSettings(GdUnit4Settings.RunSettingsXmlNode) as GdUnit4SettingsProvider;
+        var gdUnitSettingsProvider = discoveryContext.RunSettings?.GetSettings(GdUnit4Settings.RUN_SETTINGS_XML_NODE) as GdUnit4SettingsProvider;
         return gdUnitSettingsProvider?.Settings ?? new GdUnit4Settings();
     }
 }

--- a/TestAdapter/src/settings/RunSettingsProvider.cs
+++ b/TestAdapter/src/settings/RunSettingsProvider.cs
@@ -3,8 +3,6 @@
 
 namespace GdUnit4.TestAdapter.Settings;
 
-using System.Collections.Generic;
-using System.IO;
 using System.Xml;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -49,14 +47,14 @@ public static class RunSettingsProvider
 
         // over all EnvironmentVariables
         using var variables = reader.ReadSubtree();
-        variables.MoveToContent();
-        variables.Read(); // Move past the EnvironmentVariables element
+        _ = variables.MoveToContent();
+        _ = variables.Read(); // Move past the EnvironmentVariables element
         while (!variables.EOF)
         {
             if (variables.IsStartElement())
                 envVars[variables.Name] = variables.ReadElementContentAsString();
             else
-                variables.Read();
+                _ = variables.Read();
         }
 
         return envVars;

--- a/stylecop.ruleset
+++ b/stylecop.ruleset
@@ -1,26 +1,82 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Custom Ruleset" Description="Custom Ruleset" ToolsVersion="16.0">
-  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <Rule Id="SA1009" Action="None"/> <!-- Disable A closing parenthesis within a C# statement is not spaced correctly Rules-->
-    <Rule Id="SA1135" Action="None"/> <!-- Disable A using directive is not qualified. Rules-->
-    <Rule Id="SA1503" Action="None"/> <!-- Disable BracesMustNotBeOmitted -->
-    <Rule Id="SA1520" Action="None"/> <!-- Disable The opening and closing braces of a chained Rules-->
+<RuleSet Name="GdUnit4 StyleCop Ruleset" Description="StyleCop rules for GdUnit4 project with C# 12 support" ToolsVersion="16.0">
 
+  <!-- StyleCop Analyzers Rules -->
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+
+    <!-- Spacing Rules - Relaxed for modern C# -->
+    <Rule Id="SA1000" Action="None"/> <!-- Keywords should be spaced correctly -->
+    <Rule Id="SA1009" Action="None"/> <!-- Closing parenthesis should be spaced correctly -->
+
+    <!-- Readability Rules -->
+    <Rule Id="SA1101" Action="None"/> <!-- Prefix local calls with this -->
+    <Rule Id="SA1118" Action="None"/> <!-- Parameter should not span multiple lines -->
+    <Rule Id="SA1135" Action="None"/> <!-- Using directives should be qualified -->
+
+    <!-- Layout Rules -->
+    <Rule Id="SA1503" Action="None"/> <!-- Braces should not be omitted -->
+    <Rule Id="SA1520" Action="None"/> <!-- Use braces consistently -->
+
+    <!-- Naming Rules -->
+    <Rule Id="SA1310" Action="None"/> <!-- Field names should not contain underscore (allow SCREAMING_SNAKE_CASE) -->
+    <Rule Id="SA1413" Action="None"/> <!-- Use trailing comma in multi-line initializers -->
+
+    <!-- Documentation Rules - Keep strict for public API -->
+    <Rule Id="SA1633" Action="Error"/> <!-- File should have header -->
+    <Rule Id="SA1635" Action="Error"/> <!-- File header should have copyright text -->
+    <Rule Id="SA1637" Action="None"/> <!-- File header should contain file name -->
+    <Rule Id="SA1638" Action="None"/> <!-- File header file name documentation should match file name -->
+    <Rule Id="SA1634" Action="None"/> <!-- File header should show copyright -->
+
+    <!-- Ordering Rules - Keep strict for consistency -->
     <Rule Id="SA1201" Action="Error"/> <!-- Elements should appear in the correct order -->
     <Rule Id="SA1202" Action="Error"/> <!-- Elements should be ordered by access -->
     <Rule Id="SA1203" Action="Error"/> <!-- Constants should appear before fields -->
     <Rule Id="SA1204" Action="Error"/> <!-- Static elements should appear before instance elements -->
-    <Rule Id="SA1206" Action="Error"/> <!-- Declaration Keywords Must Follow Order-->
+    <Rule Id="SA1206" Action="Error"/> <!-- Declaration keywords should follow order -->
+
+    <!-- Maintainability Rules -->
+    <Rule Id="SA1507" Action="Warning"/> <!-- Code should not contain multiple blank lines -->
+
   </Rules>
+
+  <!-- C# Code Style Rules -->
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
-    <Rule Id="IDE0011" Action="None"/> <!-- Disable Add braces to 'if' statement -->
-    <!-- Disable C# 12 collection expression suggestions -->
-    <Rule Id="IDE0028" Action="None"/>
-    <Rule Id="IDE0290" Action="None"/>
-    <Rule Id="IDE0300" Action="None"/>
-    <Rule Id="IDE0301" Action="None"/>
-    <Rule Id="IDE0303" Action="None"/>
-    <Rule Id="IDE0305" Action="None"/>
-    <Rule Id="IDE0306" Action="None"/>
+
+    <!-- Disable overly strict IDE rules -->
+    <Rule Id="IDE0011" Action="None"/> <!-- Add braces -->
+    <Rule Id="IDE0130" Action="None"/> <!-- Namespace does not match folder structure -->
+
+    <!-- C# 12 Collection Expression Rules - Set as suggestions -->
+    <Rule Id="IDE0028" Action="None"/> <!-- Simplify collection initialization -->
+    <Rule Id="IDE0290" Action="None"/> <!-- Use primary constructor -->
+    <Rule Id="IDE0300" Action="None"/> <!-- Simplify collection initialization (collection expression) -->
+    <Rule Id="IDE0301" Action="None"/> <!-- Simplify collection initialization (empty collection) -->
+    <Rule Id="IDE0303" Action="None"/> <!-- Simplify collection initialization (create) -->
+    <Rule Id="IDE0305" Action="None"/> <!-- Simplify collection initialization (fluent) -->
+    <Rule Id="IDE0306" Action="None"/> <!-- Simplify collection initialization (spread) -->
+
   </Rules>
+
+  <!-- .NET Code Analysis Rules -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.NetAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.NetAnalyzers">
+
+    <!-- Globalization Rules - Relaxed for test framework -->
+    <Rule Id="CA1303" Action="None"/> <!-- Do not pass literals as localized parameters -->
+    <Rule Id="CA1304" Action="None"/> <!-- Specify CultureInfo -->
+    <Rule Id="CA1305" Action="None"/> <!-- Specify IFormatProvider -->
+    <Rule Id="CA1310" Action="None"/> <!-- Specify StringComparison for correctness -->
+    <Rule Id="CA1311" Action="None"/> <!-- Specify a culture or use an invariant version -->
+
+    <Rule Id="CA1707" Action="None"/> <!-- Identifiers should not contain underscores (allow SCREAMING_SNAKE_CASE) -->
+
+    <!-- Performance Rules - Relaxed for test scenarios -->
+    <Rule Id="CA1822" Action="None"/> <!-- Mark members as static -->
+    <Rule Id="CA1861" Action="None"/> <!-- Avoid constant arrays as arguments -->
+
+    <!-- Design Rules - Keep for API quality -->
+    <Rule Id="CA1515" Action="None"/> <!-- Consider making public types internal (disabled for test files) -->
+
+  </Rules>
+
 </RuleSet>


### PR DESCRIPTION
# Why
- Multiple configuration files had duplicated and conflicting rules
- EditorConfig contained inconsistent settings that could cause CI failures
- Missing modern C# 12 language features and best practices
- No centralized copyright header management across the solution
- StyleCop rules were scattered and not optimally organized
- Dead code analysis rules had confusing naming and documentation

# What
- Consolidated .editorconfig removing duplicates (dotnet_separate_import_directive_groups, dotnet_sort_system_directives_first)
- Resolved conflicting namespace qualification preferences (set to false for GdUnit4)
- Added comprehensive C# 12 feature support (primary constructors, collection expressions, pattern matching)
- Implemented consistent copyright header templates across .editorconfig, Directory.Build.props, and stylecop.json
- Reorganized StyleCop ruleset with proper IDE rule categories and disabled overly strict rules
- Renamed "Unnecessary Code Rules" to "Dead Code Analysis" for clarity
- Added CA1707 override to allow SCREAMING_SNAKE_CASE for constants
- Enhanced naming rules with proper precedence and SCREAMING_SNAKE_CASE support
- Added comprehensive ReSharper/Rider integration settings
- Configured source roots for proper namespace calculation in src/ folders

This provides a robust, maintainable foundation for consistent code quality across all development environments while supporting modern C# practices.