### PR TITLE
GD-211: Implement missing `AwaitSignalOn`

### DIFF
--- a/Api.Test/src/core/SceneRunnerCSharpSceneTest.cs
+++ b/Api.Test/src/core/SceneRunnerCSharpSceneTest.cs
@@ -334,6 +334,27 @@ public sealed class SceneRunnerCSharpSceneTest
     }
 
     [TestCase]
+    public async Task AwaitSignalOnSpell()
+    {
+        // fire spell be pressing an enter key
+        sceneRunner.SimulateKeyPressed(Key.Enter);
+        // wait until the next frame
+        await sceneRunner.AwaitInputProcessed();
+
+        var spell = sceneRunner.FindChild("Spell");
+        // wait until the spell is exploded after around 1 s
+        await ISceneRunner.AwaitSignalOn(spell, Spell.SignalName.SpellExplode, spell.GetInstanceId()).WithTimeout(1100);
+
+        // fire next spell be pressing an enter key
+        sceneRunner.SimulateKeyPressed(Key.Enter);
+        // wait until the next frame
+        await sceneRunner.AwaitInputProcessed();
+        spell = sceneRunner.FindChild("Spell");
+        // use global AwaitSignalOn
+        await AwaitSignalOn(spell, Spell.SignalName.SpellExplode, spell.GetInstanceId()).WithTimeout(1100);
+    }
+
+    [TestCase]
     public async Task DisposeSceneRunner()
     {
         var runner = ISceneRunner.Load("res://src/core/resources/scenes/TestSceneCSharp.tscn", true);

--- a/Api/src/Assertions.cs
+++ b/Api/src/Assertions.cs
@@ -553,6 +553,23 @@ public static class Assertions
     }
 
     /// <summary>
+    ///     Waits for the specified signal to be emitted by a particular source node.
+    ///     If the signal is not emitted within the given timeout, the operation fails.
+    /// </summary>
+    /// <example>
+    ///     <code>
+    ///      // Waits for the signal "mySignal" is emitted by myNode.
+    ///      await runner.AwaitSignalOn(myNode, "mySignal");
+    ///   </code>
+    /// </example>
+    /// <param name="source">The object from which the signal is emitted.</param>
+    /// <param name="signal">The name of the signal to wait.</param>
+    /// <param name="args">An optional set of signal arguments.</param>
+    /// <returns>Task to wait.</returns>
+    public static async Task<ISignalAssert> AwaitSignalOn(GodotObject source, string signal, params Variant[] args) =>
+        await ISceneRunner.AwaitSignalOn(source, signal, args).ConfigureAwait(true);
+
+    /// <summary>
     ///     Provides the expected line number via compiler state.
     ///     Is primarily designed to use on internal test coverage to validate the reported error line is correct.
     /// </summary>

--- a/Api/src/ISceneRunner.cs
+++ b/Api/src/ISceneRunner.cs
@@ -227,10 +227,11 @@ public interface ISceneRunner : IDisposable
 
     /// <summary>
     ///     Waits for given signal is emitted.
+    ///     If the signal is not emitted within the given timeout, the operation fails.
     /// </summary>
     /// <example>
     ///     <code>
-    ///      // Waits for signal "mySignal" is emitted by the scene.
+    ///      // Waits for the signal "mySignal" is emitted by the scene.
     ///      await runner.AwaitSignal("mySignal");
     ///   </code>
     /// </example>
@@ -238,6 +239,25 @@ public interface ISceneRunner : IDisposable
     /// <param name="args">An optional set of signal arguments.</param>
     /// <returns>Task to wait.</returns>
     Task<ISignalAssert> AwaitSignal(string signal, params Variant[] args);
+
+    /// <summary>
+    ///     Waits for the specified signal to be emitted by a particular source node.
+    ///     If the signal is not emitted within the given timeout, the operation fails.
+    /// </summary>
+    /// <example>
+    ///     <code>
+    ///      // Waits for the signal "mySignal" is emitted by myNode.
+    ///      await runner.AwaitSignalOn(myNode, "mySignal");
+    ///   </code>
+    /// </example>
+    /// <param name="source">The object from which the signal is emitted.</param>
+    /// <param name="signal">The name of the signal to wait.</param>
+    /// <param name="args">An optional set of signal arguments.</param>
+    /// <returns>Task to wait.</returns>
+    static async Task<ISignalAssert> AwaitSignalOn(GodotObject source, string signal, params Variant[] args) =>
+        await new SignalAssert(source)
+            .IsEmitted(signal, args)
+            .ConfigureAwait(true);
 
     /// <summary>
     ///     Waits for a specific number of milliseconds.

--- a/Api/src/core/SceneRunner.cs
+++ b/Api/src/core/SceneRunner.cs
@@ -248,7 +248,8 @@ internal sealed class SceneRunner : ISceneRunner
     }
 
     public async Task<ISignalAssert> AwaitSignal(string signal, params Variant[] args) =>
-        await new SignalAssert(currentScene).IsEmitted(signal, args)
+        await new SignalAssert(currentScene)
+            .IsEmitted(signal, args)
             .ConfigureAwait(true);
 
     public async Task AwaitIdleFrame() => await ISceneRunner.SyncProcessFrame;


### PR DESCRIPTION
# Why
The  `AwaitSignalOn` is missing in the API and needs to be implemented.

# What
- Add  `AwaitSignalOn` to ISceneRunner
- Add global  `AwaitSignalOn` method redirecting to ISceneRunner implementaion