### PR TITLE
GD-331: Fixing SceneRunner `SimulateKey` to provide missing Unicode

### DIFF
--- a/Api.Test/src/core/SceneRunnerInputEventIntegrationTest.cs
+++ b/Api.Test/src/core/SceneRunnerInputEventIntegrationTest.cs
@@ -741,6 +741,33 @@ public sealed class SceneRunnerInputEventIntegrationTest
         }
     }
 
+    /// <summary>
+    ///     Tests text input functionality.
+    ///     Validates keyboard input in text controls.
+    /// </summary>
+    /// <returns>
+    ///     A Task representing the asynchronous test operation.
+    /// </returns>
+    [TestCase]
+    public async Task TextInputProcessing()
+    {
+        var lineEdit = sceneRunner.FindChild("TextInput") as LineEdit
+                       ?? throw new InvalidOperationException("Could not find TextInput");
+
+        // Focus the text input and clear any existing content
+        lineEdit.GrabFocus();
+        AssertThat(lineEdit.HasFocus()).IsTrue();
+        lineEdit.Text = string.Empty;
+
+        // Type individual characters
+        sceneRunner.SimulateKeyPressed(Key.H);
+        sceneRunner.SimulateKeyPressed(Key.I);
+        await sceneRunner.AwaitInputProcessed();
+
+        // Verify text accumulation
+        AssertThat(lineEdit.Text).IsEqual("HI");
+    }
+
     [TestCase]
     public async Task MouseDragAndDrop()
     {

--- a/Api.Test/src/core/resources/scenes/TestSceneCSharp.tscn
+++ b/Api.Test/src/core/resources/scenes/TestSceneCSharp.tscn
@@ -44,9 +44,11 @@ text = "Test 3"
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+current_tab = 0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/PanelContainer"]
 layout_mode = 2
+metadata/_tab_index = 0
 
 [node name="Panel1" type="ColorRect" parent="VBoxContainer/PanelContainer/HBoxContainer"]
 custom_minimum_size = Vector2(100, 0)
@@ -98,6 +100,14 @@ default_color = Color(0.0392157, 1, 0.278431, 1)
 points = PackedVector2Array(40, 0, 60, 0)
 width = 30.0
 default_color = Color(1, 0.0392157, 0.247059, 1)
+
+[node name="TextInput" type="LineEdit" parent="."]
+unique_name_in_owner = true
+layout_mode = 0
+offset_left = 475.0
+offset_top = 227.0
+offset_right = 807.0
+offset_bottom = 315.0
 
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/test1" to="." method="OnTestPressed" binds= [1]]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/test2" to="." method="OnTestPressed" binds= [2]]

--- a/Api/ReleaseNotes.txt
+++ b/Api/ReleaseNotes.txt
@@ -8,6 +8,7 @@ v5.1.0
 * GD-319: Fixing SceneRunner.Scene() returns disposed object after the scene is auto freed.
 * GD-320: Fixing method Chaining on Asserts breaks type inference after base interface methods,
           fixes also dynamic assert bindings (missing public access).
+* GD-331: Fixing SceneRunner SimulateKey to provide missing Unicode
 
 ✨ Improvements
 * GD-311: Verify the Godot binary has C# support before running godot runtime tests to avoid invalid test execution.

--- a/Api/src/core/SceneRunner.cs
+++ b/Api/src/core/SceneRunner.cs
@@ -97,6 +97,7 @@ internal sealed class SceneRunner : ISceneRunner
             Pressed = true,
             Keycode = keyCode,
             PhysicalKeycode = keyCode,
+            Unicode = (long)keyCode,
             AltPressed = keyCode == Key.Alt,
             ShiftPressed = shiftPressed || keyCode == Key.Shift,
             CtrlPressed = controlPressed || keyCode == Key.Ctrl
@@ -121,6 +122,7 @@ internal sealed class SceneRunner : ISceneRunner
             Pressed = false,
             Keycode = keyCode,
             PhysicalKeycode = keyCode,
+            Unicode = (long)keyCode,
             AltPressed = keyCode == Key.Alt,
             ShiftPressed = shiftPressed || keyCode == Key.Shift,
             CtrlPressed = controlPressed || keyCode == Key.Ctrl

--- a/ProjectVersions.props
+++ b/ProjectVersions.props
@@ -2,7 +2,7 @@
   <!-- GdUnit4 Component Versions -->
   <PropertyGroup>
     <GdUnitAnalyzersVersion>1.0.0</GdUnitAnalyzersVersion>
-    <GdUnitAPIVersion>5.1.0-alpha1</GdUnitAPIVersion>
+    <GdUnitAPIVersion>5.1.0-alpha2</GdUnitAPIVersion>
     <GdUnitTestAdapterVersion>3.0.1</GdUnitTestAdapterVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
# Why
The `SimulateKey ` produces an `InputEventKey` without setting the Unicode value. This will result in possible issues on text input components that act on Unicode values.

# What
- Set the missing `Unicode` on  `InputEventKey` creation
- Add test coverage to simulate an text input