### PR TITLE
GD-340: Fixing GdUnit4NetApiGodotBridge test discovery on linux paths

### DIFF
--- a/Api/ReleaseNotes.txt
+++ b/Api/ReleaseNotes.txt
@@ -9,6 +9,7 @@ v5.1.0
 * GD-320: Fixing method Chaining on Asserts breaks type inference after base interface methods,
           fixes also dynamic assert bindings (missing public access).
 * GD-331: Fixing SceneRunner SimulateKey to provide missing Unicode
+* GD-340: Fixing GdUnit4NetApiGodotBridge test discovery on linux paths
 
 ✨ Improvements
 * GD-311: Verify the Godot binary has C# support before running godot runtime tests to avoid invalid test execution.

--- a/Api/src/core/discovery/TestCaseDiscoverer.cs
+++ b/Api/src/core/discovery/TestCaseDiscoverer.cs
@@ -92,6 +92,7 @@ internal static class TestCaseDiscoverer
     public static IReadOnlyList<TestCaseDescriptor> DiscoverTestCasesFromScript(CSharpScript sourceScript)
     {
         ArgumentNullException.ThrowIfNull(sourceScript);
+        Logger.LogInfo($"Discover tests for script: {sourceScript.ResourcePath}");
 
         try
         {
@@ -457,6 +458,6 @@ internal static class TestCaseDiscoverer
         => type.Methods.Any(method =>
         {
             var navData = GetNavigationDataOrDefault(method);
-            return navData.CodeFilePath == sourceScriptPath;
+            return string.Equals(navData.CodeFilePath, sourceScriptPath, StringComparison.OrdinalIgnoreCase);
         });
 }

--- a/Example/ExampleProject.csproj
+++ b/Example/ExampleProject.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <!-- We only include here the MSTest framework to run tests mixed with MSTest assertions, but set it to private to prevent conflicts -->
         <PackageReference Include="MSTest.TestFramework" Version="3.10.4" ExcludeAssets="build;analyzers;native"/>
-        <PackageReference Include="gdUnit4.api" Version="5.1.0-alpha2"/>
+        <PackageReference Include="gdUnit4.api" Version="5.1.0-alpha3"/>
         <PackageReference Include="gdUnit4.test.adapter" Version="3.0.0"/>
         <PackageReference Include="gdUnit4.analyzers" Version="1.0.0">
             <PrivateAssets>none</PrivateAssets>

--- a/ProjectVersions.props
+++ b/ProjectVersions.props
@@ -2,7 +2,7 @@
   <!-- GdUnit4 Component Versions -->
   <PropertyGroup>
     <GdUnitAnalyzersVersion>1.0.0</GdUnitAnalyzersVersion>
-    <GdUnitAPIVersion>5.1.0-alpha2</GdUnitAPIVersion>
+    <GdUnitAPIVersion>5.1.0-alpha3</GdUnitAPIVersion>
     <GdUnitTestAdapterVersion>3.0.1</GdUnitTestAdapterVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
# Why
The script test discovery was broken on linux bash when having camel case names in the path.

# What
- Do compare the script and navData path ignoring camel case.