### PR TITLE
GD-343: Fix broken dictionary comparison at `GodotObjectExtensions `

### DIFF
--- a/Api.Test/src/asserts/AssertEnumerableConditions.cs
+++ b/Api.Test/src/asserts/AssertEnumerableConditions.cs
@@ -126,6 +126,9 @@ public class AssertEnumerableConditions
                 .Replace("$obj5", ValueFormatter.AsString(obj5)));
     }
 
+    protected void ContainsUsingDictionaryWithDifferentOrder(dynamic current, dynamic expected)
+        => AssertArray(current).HasSize(1).Contains(expected);
+
     protected void DoContainsSame(dynamic current, dynamic obj5)
     {
         var obj1 = current[0];

--- a/Api.Test/src/asserts/CSharpTypes/AssertEnumerableTest.cs
+++ b/Api.Test/src/asserts/CSharpTypes/AssertEnumerableTest.cs
@@ -194,6 +194,35 @@ public class AssertEnumerableTest : AssertEnumerableConditions
         => DoContains(current, obj5);
 
     [TestCase]
+    public void ContainsUsingDictionaryWithDifferentOrder()
+        => ContainsUsingDictionaryWithDifferentOrder(new object[]
+        {
+            new Dictionary<string, object>
+            {
+                ["managed_type"] = "gdUnit4.addons.gdUnit4.test.dotnet.ExampleTestSuite",
+                ["test_name"] = "IsFoo",
+                ["source_file"] = "res://addons/gdUnit4/test/dotnet/ExampleTestSuite.cs",
+                ["line_number"] = 16,
+                ["attribute_index"] = 0,
+                ["require_godot_runtime"] = true,
+                ["code_file_path"] = "res://addons/gdUnit4/test/dotnet/ExampleTestSuite.cs",
+                ["fully_qualified_name"] = "gdUnit4.addons.gdUnit4.test.dotnet.ExampleTestSuite.IsFoo",
+                ["simple_name"] = "IsFoo"
+            }
+        }, new Dictionary<string, object>
+        {
+            ["test_name"] = "IsFoo",
+            ["source_file"] = "res://addons/gdUnit4/test/dotnet/ExampleTestSuite.cs",
+            ["line_number"] = 16,
+            ["attribute_index"] = 0,
+            ["require_godot_runtime"] = true,
+            ["code_file_path"] = "res://addons/gdUnit4/test/dotnet/ExampleTestSuite.cs",
+            ["fully_qualified_name"] = "gdUnit4.addons.gdUnit4.test.dotnet.ExampleTestSuite.IsFoo",
+            ["simple_name"] = "IsFoo",
+            ["managed_type"] = "gdUnit4.addons.gdUnit4.test.dotnet.ExampleTestSuite"
+        });
+
+    [TestCase]
     public void ContainsSame()
     {
         var current = new object[] { new SimpleObject("A1"), new SimpleObject("A2"), new SimpleObject("A3"), new SimpleObject("A4") };

--- a/Api.Test/src/asserts/GodotTypes/AssertEnumerableTest.cs
+++ b/Api.Test/src/asserts/GodotTypes/AssertEnumerableTest.cs
@@ -206,6 +206,34 @@ public class AssertEnumerableTest : AssertEnumerableConditions
     public void Contains(string name, dynamic current, dynamic empty, dynamic obj5)
         => DoContains(current, obj5);
 
+    [TestCase]
+    public void ContainsUsingDictionaryWithDifferentOrder()
+        => ContainsUsingDictionaryWithDifferentOrder(new Array
+        {
+            new Dictionary
+            {
+                ["managed_type"] = "gdUnit4.addons.gdUnit4.test.dotnet.ExampleTestSuite",
+                ["test_name"] = "IsFoo",
+                ["source_file"] = "res://addons/gdUnit4/test/dotnet/ExampleTestSuite.cs",
+                ["line_number"] = 16,
+                ["attribute_index"] = 0,
+                ["require_godot_runtime"] = true,
+                ["code_file_path"] = "res://addons/gdUnit4/test/dotnet/ExampleTestSuite.cs",
+                ["fully_qualified_name"] = "gdUnit4.addons.gdUnit4.test.dotnet.ExampleTestSuite.IsFoo",
+                ["simple_name"] = "IsFoo"
+            }
+        }, new Dictionary
+        {
+            ["test_name"] = "IsFoo",
+            ["source_file"] = "res://addons/gdUnit4/test/dotnet/ExampleTestSuite.cs",
+            ["line_number"] = 16,
+            ["attribute_index"] = 0,
+            ["require_godot_runtime"] = true,
+            ["code_file_path"] = "res://addons/gdUnit4/test/dotnet/ExampleTestSuite.cs",
+            ["fully_qualified_name"] = "gdUnit4.addons.gdUnit4.test.dotnet.ExampleTestSuite.IsFoo",
+            ["simple_name"] = "IsFoo",
+            ["managed_type"] = "gdUnit4.addons.gdUnit4.test.dotnet.ExampleTestSuite"
+        });
 
     [TestCase]
     public void ContainsSame()


### PR DESCRIPTION
# Why
When comparing an enumerable containing dictionaries, the comparison fails when the keys have a different order but it should succeeded.

# What
- Adding check for dictionary type not compare it as enumerable
- Adding custom dictionary comparing to verify has same count and contains same keys and values