### PR TITLE
GD-339: Allow single `NULL` value as TestCase argument

### DIFF
--- a/Api.Test/src/core/TestSuiteTestAttributeUsage.cs
+++ b/Api.Test/src/core/TestSuiteTestAttributeUsage.cs
@@ -1,0 +1,65 @@
+﻿namespace GdUnit4.Tests.Core;
+
+using static Assertions;
+
+[TestSuite]
+public sealed class TestSuiteTestAttributeUsage
+{
+    [TestCase]
+    [TestCategory("CategoryA")]
+    [Trait("Category", "Foo")]
+    public void TestFoo()
+        => AssertBool(true).IsEqual(true);
+
+    [TestCase]
+    public void TestBar()
+        => AssertBool(true).IsEqual(true);
+
+
+    [TestCase(TestName = "Customized")]
+    public void TestFooBar()
+        => AssertBool(true).IsEqual(true);
+
+    [TestCase(1, 2, 3, 6, TestName = "TestCaseA")]
+    [TestCase(3, 4, 5, 12, TestName = "TestCaseB")]
+    [TestCase(6, 7, 8, 21, TestName = "TestCaseC")]
+    public void TestCasesWithCustomTestName(int a, double b, int c, int expect)
+        => AssertThat(a + b + c).IsEqual(expect);
+
+    [TestCase(true)]
+    public void ParameterizedSingleTest(bool value)
+        => AssertThat(value).IsTrue();
+
+    [TestCase("")]
+    [TestCase(null)]
+    public void ParameterizedSingleNullValue(object? value)
+        => AssertThat(value == null || value.Equals("")).IsTrue();
+
+    [TestCase("foo", null)]
+    public void ParameterizedSingleTestNullValues(object? value1, object? value2)
+    {
+        AssertThat(value1).IsEqual("foo");
+        AssertThat(value2).IsNull();
+    }
+
+    [TestCase]
+    [IgnoreUntil(Until = "2030-08-23 22:56:00", Description = "Ignored until Aug 23, 2030 22:56 local time")]
+    public void SkippedUntilLocalDate()
+        => AssertBool(false)
+            .OverrideFailureMessage("Should never be called before Aug 23, 2030 22:56 local time")
+            .IsTrue();
+
+    [TestCase]
+    [IgnoreUntil(UntilUtc = "2030-08-23 20:56:00", Description = "Ignored until Aug 23, 2030 20:56 UTC (22:56 CEST)")]
+    public void SkippedUntilUtcDate()
+        => AssertBool(false)
+            .OverrideFailureMessage("Should never be called before Aug 23, 2030 20:56 UTC")
+            .IsTrue();
+
+    [TestCase]
+    [IgnoreUntil(Description = "Permanently ignored until attribute is removed")]
+    public void Skipped()
+        => AssertBool(false)
+            .OverrideFailureMessage("Should never be called, this test is skipped")
+            .IsTrue();
+}

--- a/Api/ReleaseNotes.txt
+++ b/Api/ReleaseNotes.txt
@@ -9,6 +9,7 @@ v5.1.0
 * GD-320: Fixing method Chaining on Asserts breaks type inference after base interface methods,
           fixes also dynamic assert bindings (missing public access).
 * GD-331: Fixing SceneRunner SimulateKey to provide missing Unicode
+* GD-339: Fixing to allow single `NULL` value as TestCase argument e.g `[TestCase(null)]`
 * GD-340: Fixing GdUnit4NetApiGodotBridge test discovery on linux paths
 
 ✨ Improvements

--- a/Api/src/core/attributes/TestCaseAttribute.cs
+++ b/Api/src/core/attributes/TestCaseAttribute.cs
@@ -5,8 +5,6 @@
 // Need to be placed in the root namespace to be accessible by the test runner.
 namespace GdUnit4;
 
-using System;
-
 /// <summary>
 ///     Attribute used to define test cases, including both simple and parameterized tests.
 ///     This attribute can be used to mark a method as a test or to execute a test method multiple times with different input arguments.
@@ -40,9 +38,9 @@ public sealed class TestCaseAttribute : TestStageAttribute
     ///     Initializes a new instance of the <see cref="TestCaseAttribute" /> class with the specified arguments.
     /// </summary>
     /// <param name="arguments">The arguments to pass to the test method during execution.</param>
-    public TestCaseAttribute(params object?[] arguments)
+    public TestCaseAttribute(params object?[]? arguments)
         : base(string.Empty, -1)
-        => Arguments = arguments;
+        => Arguments = arguments ?? [null];
 
     /// <summary>
     ///     Gets or sets the starting point of random values by given seed.


### PR DESCRIPTION
# Why
When running test cases with parameters, using a single null parameter, it throws an exception and all test execution stops.
`[TestCase(null)]`

# What
- Test for single null value and convert to an argument list containing a single null value