### PR TITLE
GD-333: Fixing broken Signal assertion task handling

### DIFF
--- a/Api.Test/src/asserts/SignalAssertTest.cs
+++ b/Api.Test/src/asserts/SignalAssertTest.cs
@@ -36,6 +36,7 @@ public partial class SignalAssertTest
         await AssertThrown(AssertSignal(node).IsEmitted("SignalC", "abc", 101).WithTimeout(200))
             .ContinueWith(result => result.Result?
                 .IsInstanceOf<TestFailedException>()
+                .HasFileLineNumber(36)
                 .HasMessage("""
                     Expecting do emitting signal:
                         "SignalC(["abc", 101])"
@@ -205,7 +206,7 @@ public partial class SignalAssertTest
                 .OverrideFailureMessage("custom error")
                 .IsSignalExists("foo"))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(204)
+            .HasFileLineNumber(205)
             .HasMessage("custom error");
     }
 
@@ -217,7 +218,7 @@ public partial class SignalAssertTest
                 .AppendFailureMessage("custom data")
                 .IsSignalExists("foo"))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(216)
+            .HasFileLineNumber(217)
             .HasMessage($"""
                          Expecting signal exists:
                              "foo()"

--- a/Api.Test/src/core/SceneRunnerCSharpSceneTest.cs
+++ b/Api.Test/src/core/SceneRunnerCSharpSceneTest.cs
@@ -12,6 +12,8 @@ using GdUnit4.Core.Execution.Exceptions;
 
 using Godot;
 
+using Resources.Scenes;
+
 using static Assertions;
 
 [RequireGodotRuntime]
@@ -332,6 +334,47 @@ public sealed class SceneRunnerCSharpSceneTest
         await sceneRunner.AwaitSignal(TestScene.SignalName.PanelColorChange, box1, new Color(1, 0, 0)); // Red
         await sceneRunner.AwaitSignal(TestScene.SignalName.PanelColorChange, box1, new Color(0, 0, 1)); // Blue
         await sceneRunner.AwaitSignal(TestScene.SignalName.PanelColorChange, box1, new Color(0, 1, 0)); // Green
+    }
+
+    [TestCase]
+    public async Task SignalAwaitSignal()
+    {
+        var runner = ISceneRunner.Load("res://src/core/resources/scenes/TestSceneWithButton.tscn", true);
+        var scene = runner.Scene() as TestSceneWithButton;
+
+        await ISceneRunner.SyncProcessFrame;
+
+        // Trigger start game
+        AssertThat(scene.GameState).IsEqual(TestSceneWithButton.GState.Initializing);
+        scene.OnButtonPressed();
+
+        // The game will stop after around 300ms
+        await scene.AwaitSignal(TestSceneWithButton.SignalName.GameStopped).WithTimeout(300);
+    }
+
+    [TestCase]
+    public async Task SignalMonitorSequence()
+    {
+        var runner = ISceneRunner.Load("res://src/core/resources/scenes/TestSceneWithButton.tscn", true);
+        var scene = runner.Scene() as TestSceneWithButton;
+        var monitor = AssertSignal(scene).StartMonitoring();
+
+        AssertThat(scene.GameState).IsEqual(TestSceneWithButton.GState.Initializing);
+
+        // Trigger game start
+        scene.OnButtonPressed();
+
+        // game start signal should be emitted and the state is running
+        await monitor.IsEmitted(TestSceneWithButton.SignalName.GameStarted).WithTimeout(1);
+        AssertThat(scene.GameState).IsEqual(TestSceneWithButton.GState.Running);
+
+        // the game will run about 500ms, so no stop signal is emitted yet
+        await monitor.IsNotEmitted(TestSceneWithButton.SignalName.GameStopped).WithTimeout(1);
+        AssertThat(scene.GameState).IsEqual(TestSceneWithButton.GState.Running);
+
+        // The game will stop after around 300ms
+        await monitor.IsEmitted(TestSceneWithButton.SignalName.GameStopped).WithTimeout(300);
+        AssertThat(scene.GameState).IsEqual(TestSceneWithButton.GState.Stopped);
     }
 
     [TestCase]

--- a/Api.Test/src/core/resources/scenes/TestSceneWithButton.cs
+++ b/Api.Test/src/core/resources/scenes/TestSceneWithButton.cs
@@ -1,0 +1,113 @@
+namespace GdUnit4.Tests.Core.Resources.Scenes;
+
+using System;
+using System.Diagnostics;
+
+using Godot;
+
+using Timer = Godot.Timer;
+
+public partial class TestSceneWithButton : Control
+{
+    [Signal]
+    public delegate void GameExitedEventHandler();
+
+    [Signal]
+    public delegate void GameStartedEventHandler();
+
+    [Signal]
+    public delegate void GameStoppedEventHandler();
+
+    public enum GState
+    {
+        Initializing,
+        Started,
+        Stopped,
+        Running,
+        Exiting
+    }
+
+    public Vector2 LastMousePosition { get; private set; }
+
+    public MouseButton LastMouseButton { get; private set; }
+
+    public Key LastKeyPressed { get; private set; }
+
+    private bool LetsThrowAnException { get; set; }
+
+    public GState GameState { get; set; } = GState.Initializing;
+
+    public override void _Ready()
+    {
+        GD.Print("_Ready");
+        Connect(SignalName.GameStarted, Callable.From(StartGame));
+    }
+
+    public override void _Input(InputEvent @event)
+    {
+        Debug.Assert(@event != null, nameof(@event) + " != null");
+        GD.PrintS(@event.AsText());
+        if (@event is InputEventMouseMotion mouseMotion)
+        {
+            LastMousePosition = mouseMotion.Position;
+            return;
+        }
+
+        if (@event is InputEventMouseButton mouseButton)
+        {
+            LastMousePosition = mouseButton.Position;
+            LastMouseButton = mouseButton.ButtonIndex;
+            return;
+        }
+
+        if (@event is InputEventKey keyEvent)
+            if (keyEvent.Pressed)
+            {
+                LastKeyPressed = keyEvent.Keycode;
+                if (keyEvent.Keycode == Key.Space)
+                    EmitSignal(SignalName.GameStarted);
+                if (keyEvent.Keycode == Key.E)
+                    LetsThrowAnException = true;
+            }
+    }
+
+    public override async void _Process(double delta)
+    {
+        var deltaMs = delta * 1000.0;
+        GD.Print($" Delta time: {deltaMs:F2} ms");
+
+
+        if (LetsThrowAnException)
+        {
+            ThrowTestException();
+            LetsThrowAnException = false;
+        }
+
+        if (GameState == GState.Started)
+        {
+            GameState = GState.Running;
+            GD.PrintS("Try Game stopping");
+            // We wait 100ms before we emit game stopped signal
+            var timer = GetTree().CreateTimer(.2);
+            await ToSignal(timer, Timer.SignalName.Timeout);
+            GD.PrintS("Game stopped");
+            GameState = GState.Stopped;
+            EmitSignal(SignalName.GameStopped);
+        }
+    }
+
+    public void OnButtonPressed()
+    {
+        GD.Print("OnButtonPressed");
+        EmitSignal(SignalName.GameStarted);
+    }
+
+    public void ThrowTestException()
+        => throw new InvalidOperationException("Method execution failed");
+
+    private void StartGame()
+    {
+        GameState = GState.Started;
+        GD.PrintS("Game started");
+    }
+}

--- a/Api.Test/src/core/resources/scenes/TestSceneWithButton.tscn
+++ b/Api.Test/src/core/resources/scenes/TestSceneWithButton.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=2 format=3 uid="uid://c8aagra25qdm4"]
+
+[ext_resource type="Script" path="res://src/core/resources/scenes/TestSceneWithButton.cs" id="1_vn4rj"]
+
+[node name="TestScene" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_vn4rj")
+
+[node name="ExampleButton" type="Button" parent="."]
+unique_name_in_owner = true
+layout_mode = 0
+offset_left = 168.0
+offset_top = 149.0
+offset_right = 305.0
+offset_bottom = 200.0
+text = "Press Me"
+
+[node name="TextInput" type="LineEdit" parent="."]
+unique_name_in_owner = true
+layout_mode = 0
+offset_left = 181.0
+offset_top = 299.0
+offset_right = 604.0
+offset_bottom = 374.0
+caret_blink = true
+
+[connection signal="pressed" from="ExampleButton" to="." method="OnButtonPressed"]

--- a/Api/src/ISceneRunner.cs
+++ b/Api/src/ISceneRunner.cs
@@ -256,10 +256,9 @@ public interface ISceneRunner : IDisposable
     /// <param name="signal">The name of the signal to wait.</param>
     /// <param name="args">An optional set of signal arguments.</param>
     /// <returns>Task to wait.</returns>
-    static async Task<ISignalConstraint> AwaitSignalOn(GodotObject source, string signal, params Variant[] args) =>
-        await new SignalAssert(source)
-            .IsEmitted(signal, args)
-            .ConfigureAwait(true);
+    static Task<ISignalConstraint> AwaitSignalOn(GodotObject source, string signal, params Variant[] args) =>
+        new SignalAssert(source)
+            .IsEmitted(signal, args);
 
     /// <summary>
     ///     Waits for a specific number of milliseconds.

--- a/Api/src/api/GodotAwaiterExtension.cs
+++ b/Api/src/api/GodotAwaiterExtension.cs
@@ -47,8 +47,8 @@ public static class GodotAwaiterExtension
     ///     The signal monitoring continues until the expected signal is emitted or the operation is cancelled.
     ///     Use <see cref="WithTimeout{TVariant}" /> to prevent indefinite waiting.
     /// </remarks>
-    public static async Task<ISignalConstraint> AwaitSignal(this Node emitter, string signal, params Variant[] args)
-        => await new SignalAssert(emitter).IsEmitted(signal, args).ConfigureAwait(true);
+    public static Task<ISignalConstraint> AwaitSignal(this Node emitter, string signal, params Variant[] args)
+        => new SignalAssert(emitter).IsEmitted(signal, args);
 
     /// <summary>
     ///     Adds a timeout to any awaitable task, preventing indefinite waiting.

--- a/Api/src/core/SceneRunner.cs
+++ b/Api/src/core/SceneRunner.cs
@@ -310,10 +310,9 @@ internal sealed class SceneRunner : ISceneRunner
         IsDisposed = true;
     }
 
-    public async Task<ISignalConstraint> AwaitSignal(string signal, params Variant[] args) =>
-        await new SignalAssert(currentScene)
-            .IsEmitted(signal, args)
-            .ConfigureAwait(true);
+    public Task<ISignalConstraint> AwaitSignal(string signal, params Variant[] args) =>
+        new SignalAssert(currentScene)
+            .IsEmitted(signal, args);
 
     internal static MouseButtonMask ToMouseButtonMask(MouseButton button)
     {

--- a/Api/src/core/execution/exceptions/TestFailedException.cs
+++ b/Api/src/core/execution/exceptions/TestFailedException.cs
@@ -85,10 +85,26 @@ public sealed class TestFailedException : Exception
     ///     it reaches a method marked with <see cref="TestCaseAttribute" />.
     /// </remarks>
     public TestFailedException(string message)
+        : this(message, new StackTrace(true))
+    {
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="TestFailedException" /> class with automatic stack trace filtering.
+    /// </summary>
+    /// <param name="message">The message that describes the test failure.</param>
+    /// <param name="stackTrace">The current stack trace.</param>
+    /// <remarks>
+    ///     This constructor performs intelligent stack trace filtering to show only test-related frames,
+    ///     excluding GdUnit4 framework internals and system calls. It stops collecting frames when
+    ///     it reaches a method marked with <see cref="TestCaseAttribute" />.
+    /// </remarks>
+    public TestFailedException(string message, StackTrace stackTrace)
         : base(message)
     {
         var stackFrames = new StringBuilder();
-        foreach (var frame in new StackTrace(true).GetFrames())
+        Debug.Assert(stackTrace != null, nameof(stackTrace) + " != null");
+        foreach (var frame in stackTrace.GetFrames())
         {
             var mb = frame.GetMethod();
 


### PR DESCRIPTION
# Why
I want to verify a signal is not emitted in a given time frame, but it breaks my before successful running test. The signal assert extension is broken, the `WithTimeout` is not canceling the running task.

# What
There was many issues how the signal assertion is creating/cancel and continuation the signal task.
- Complete reworked on the signal assert task handling
- Using a thread save map to store the task id and cancelation token to handle `WithTimeout` cancelation the running signal task
- Removed redundant task recreation to have a stable task id for cancelation
- Fixing signal assert exceptions creation using the correct stacktrace