### PR TITLE
GD-348: Fixing task handling using `AwaitMethod` with `WithTimeout`

### DIFF
--- a/Api.Test/src/core/SceneRunnerCSharpSceneTest.cs
+++ b/Api.Test/src/core/SceneRunnerCSharpSceneTest.cs
@@ -320,7 +320,10 @@ public sealed class SceneRunnerCSharpSceneTest
 
         // wait for returns 'red' but will never happen and expect is interrupted after 150ms
         await AssertThrown(sceneRunner.AwaitMethod<string>("ColorCycle").IsEqual("red").WithTimeout(150))
-            .ContinueWith(result => result.Result?.HasMessage("Assertion: Timed out after 150ms."));
+            .ContinueWith(result
+                => result.Result?
+                    .HasMessage("Assertion: Timed out after 150ms.")
+                    .HasFileLineNumber(322));
     }
 
     [TestCase]
@@ -341,6 +344,7 @@ public sealed class SceneRunnerCSharpSceneTest
     {
         var runner = ISceneRunner.Load("res://src/core/resources/scenes/TestSceneWithButton.tscn", true);
         var scene = runner.Scene() as TestSceneWithButton;
+        Debug.Assert(scene != null, nameof(scene) + " != null");
 
         await ISceneRunner.SyncProcessFrame;
 
@@ -357,6 +361,7 @@ public sealed class SceneRunnerCSharpSceneTest
     {
         var runner = ISceneRunner.Load("res://src/core/resources/scenes/TestSceneWithButton.tscn", true);
         var scene = runner.Scene() as TestSceneWithButton;
+        Debug.Assert(scene != null, nameof(scene) + " != null");
         var monitor = AssertSignal(scene).StartMonitoring();
 
         AssertThat(scene.GameState).IsEqual(TestSceneWithButton.GState.Initializing);

--- a/Api.Test/src/core/SceneRunnerGDScriptSceneTest.cs
+++ b/Api.Test/src/core/SceneRunnerGDScriptSceneTest.cs
@@ -256,7 +256,10 @@ public class SceneRunnerGDScriptSceneTest
 
         // wait for returns 'red' but will never happen and expect is interrupted after 150ms
         await AssertThrown(sceneRunner.AwaitMethod<string>("color_cycle").IsEqual("red").WithTimeout(150))
-            .ContinueWith(result => result.Result?.HasMessage("Assertion: Timed out after 150ms."));
+            .ContinueWith(result
+                => result.Result?
+                    .HasMessage("Assertion: Timed out after 150ms.")
+                    .HasFileLineNumber(258));
     }
 
     [TestCase]

--- a/Api/ReleaseNotes.txt
+++ b/Api/ReleaseNotes.txt
@@ -12,6 +12,7 @@ v5.1.0
 * GD-333: Fixing broken Signal assertion task handling
 * GD-339: Fixing to allow single `NULL` value as TestCase argument e.g `[TestCase(null)]`
 * GD-340: Fixing GdUnit4NetApiGodotBridge test discovery on linux paths
+* GD-348: Fixing task handling using AwaitMethod with WithTimeout
 
 ✨ Improvements
 * GD-311: Verify the Godot binary has C# support before running godot runtime tests to avoid invalid test execution.

--- a/Api/src/core/execution/ExecutionStage.cs
+++ b/Api/src/core/execution/ExecutionStage.cs
@@ -93,7 +93,7 @@ internal abstract class ExecutionStage<T> : IExecutionStage
             if (ValidateForExpectedException(context, e))
                 return;
             if (context.FailureReporting)
-                context.ReportCollector.Consume(new TestReport(Interrupted, e.LineNumber, e.Message));
+                context.ReportCollector.Consume(new TestReport(Interrupted, e));
         }
         catch (TestFailedException e)
         {

--- a/Api/src/core/execution/exceptions/ExecutionTimeoutException.cs
+++ b/Api/src/core/execution/exceptions/ExecutionTimeoutException.cs
@@ -3,29 +3,39 @@
 
 namespace GdUnit4.Core.Execution.Exceptions;
 
-using System;
+using System.Diagnostics;
 
 #pragma warning disable CA1064
-internal sealed class ExecutionTimeoutException : Exception
+internal sealed class ExecutionTimeoutException : TestFailedException
 #pragma warning restore CA1064
 {
     public ExecutionTimeoutException()
+        : base("Execution timed out", new StackTrace(true))
     {
     }
 
     public ExecutionTimeoutException(string message)
-         : base(message)
+        : base(message, new StackTrace(true))
+    {
+    }
+
+    public ExecutionTimeoutException(string message, StackTrace stackTrace)
+        : base(message, stackTrace)
     {
     }
 
     public ExecutionTimeoutException(string message, Exception innerException)
-         : base(message, innerException)
-    {
-    }
+        : base(message, innerException)
+        => SetCurrentStackTrace(innerException);
 
     public ExecutionTimeoutException(string message, int line)
         : base(message)
         => LineNumber = line;
 
-    public int LineNumber { get; private set; }
+    [StackTraceHidden]
+    private void SetCurrentStackTrace(Exception innerException)
+    {
+        LineNumber = innerException is ExecutionTimeoutException ete ? ete.LineNumber : -1;
+        OriginalStackTrace = innerException.StackTrace;
+    }
 }

--- a/Api/src/core/execution/exceptions/TestFailedException.cs
+++ b/Api/src/core/execution/exceptions/TestFailedException.cs
@@ -27,7 +27,7 @@ using System.Text;
 ///     </para>
 /// </remarks>
 [Serializable]
-public sealed class TestFailedException : Exception
+public class TestFailedException : Exception
 {
     /// <summary>
     ///     Initializes a new instance of the <see cref="TestFailedException" /> class.
@@ -168,7 +168,7 @@ public sealed class TestFailedException : Exception
     public override string? StackTrace => OriginalStackTrace ?? base.StackTrace;
 
     /// <summary>
-    ///     Gets the line number in the source file where the test failure occurred.
+    ///     Gets or sets the line number in the source file where the test failure occurred.
     /// </summary>
     /// <value>
     ///     The line number where the failure occurred, or -1 if the line number could not be determined.
@@ -177,7 +177,7 @@ public sealed class TestFailedException : Exception
     ///     This property is automatically populated by analyzing the call stack or can be
     ///     explicitly set through constructor parameters for precise failure location reporting.
     /// </remarks>
-    public int LineNumber { get; private set; } = -1;
+    public int LineNumber { get; protected set; } = -1;
 
     /// <summary>
     ///     Gets the name of the source file where the test failure occurred.

--- a/Api/src/core/reporting/TestReport.cs
+++ b/Api/src/core/reporting/TestReport.cs
@@ -27,8 +27,13 @@ internal sealed class TestReport : ITestReport, IEquatable<TestReport>
     }
 
     public TestReport(TestFailedException e)
+        : this(ReportType.Failure, e)
     {
-        Type = ReportType.Failure;
+    }
+
+    public TestReport(ReportType type, TestFailedException e)
+    {
+        Type = type;
         LineNumber = e.LineNumber;
         Message = e.Message;
         StackTrace = e.StackTrace;

--- a/Api/src/core/signals/GodotSignalCollector.cs
+++ b/Api/src/core/signals/GodotSignalCollector.cs
@@ -17,8 +17,6 @@ using Error = Godot.Error;
 
 internal sealed partial class GodotSignalCollector : RefCounted
 {
-    internal const string SIGNAL_CANCELLATION_TOKEN_SLOT_NAME = "SignalCancellationToken";
-
     internal static readonly ConcurrentDictionary<int, CancellationTokenSource> TaskCancellations = new();
 
     public static GodotSignalCollector Instance { get; } = new();

--- a/Example/ExampleProject.csproj
+++ b/Example/ExampleProject.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <!-- We only include here the MSTest framework to run tests mixed with MSTest assertions, but set it to private to prevent conflicts -->
         <PackageReference Include="MSTest.TestFramework" Version="3.10.4" ExcludeAssets="build;analyzers;native"/>
-        <PackageReference Include="gdUnit4.api" Version="5.1.0-alpha3"/>
+        <PackageReference Include="gdUnit4.api" Version="5.1.0-rc1"/>
         <PackageReference Include="gdUnit4.test.adapter" Version="3.0.0"/>
         <PackageReference Include="gdUnit4.analyzers" Version="1.0.0">
             <PrivateAssets>none</PrivateAssets>

--- a/ProjectVersions.props
+++ b/ProjectVersions.props
@@ -2,7 +2,7 @@
   <!-- GdUnit4 Component Versions -->
   <PropertyGroup>
     <GdUnitAnalyzersVersion>1.0.0</GdUnitAnalyzersVersion>
-    <GdUnitAPIVersion>5.1.0-alpha3</GdUnitAPIVersion>
+    <GdUnitAPIVersion>5.1.0-rc1</GdUnitAPIVersion>
     <GdUnitTestAdapterVersion>3.0.1</GdUnitTestAdapterVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
# Why
When waiting for a method and specify a timeout, the original method task is not canceled when the timeout is reached. This will result the original task is still running, and the cancellation toke is not freed.

# What
- Rework on `GodotMethodAwaitable` task creation
- Using a thread save map to store the task id and cancellation token to handle `WithTimeout` cancellation of the running task
- Removed redundant task recreation to have a stable task id for cancellation
- Fixing `ExecutionTimeoutException` creation using the correct stack trace


Bump to release candidate 1